### PR TITLE
Allow localThreshold to be configured

### DIFF
--- a/doc/2-configuring.md
+++ b/doc/2-configuring.md
@@ -31,14 +31,15 @@ spark.mongodb.input.maxChunkSize           | The maximum chunk size for partitio
 
 The following options are available on `SparkConf` object:
 
-Property name                                | Description                                                     | Default value
----------------------------------------------|-----------------------------------------------------------------|--------------------
-spark.mongodb.output.uri                     | The connnection string                                          |
-spark.mongodb.output.database                | The database name to write data to                              |
-spark.mongodb.output.collection              | The collection name to write data to                            |
-spark.mongodb.output.writeConcern.w          | The write concern w value                                       | (WriteConcern.ACKNOWLEDGED)
-spark.mongodb.output.writeConcern.journal    | The write concern journal value                                 |
-spark.mongodb.output.writeConcern.wTimeoutMS | The write concern wTimeout value                                |
+Property name                                | Description                                                       | Default value
+---------------------------------------------|-------------------------------------------------------------------|--------------------
+spark.mongodb.output.uri                     | The connnection string                                            |
+spark.mongodb.output.database                | The database name to write data to                                |
+spark.mongodb.output.collection              | The collection name to write data to                              |
+spark.mongodb.input.localThreshold           | The threshold for choosing a server from multiple MongoDB servers | 15 ms
+spark.mongodb.output.writeConcern.w          | The write concern w value                                         | (WriteConcern.ACKNOWLEDGED)
+spark.mongodb.output.writeConcern.journal    | The write concern journal value                                   |
+spark.mongodb.output.writeConcern.wTimeoutMS | The write concern wTimeout value                                  |
 
 -----
 **Note**: When passing output configurations via an options Map then the prefix `spark.mongodb.output.` is not needed.
@@ -63,11 +64,23 @@ spark.mongodb.input.collection=collectionName
 spark.mongodb.input.readPreference.name=primaryPreferred
 ```
 
-## Cache configuration
+## Configuration via system properties
 
 The MongoConnector includes a cache for MongoClients, so workers can share the MongoClient across threads. As the cache is setup before the
 Spark Configuration is available it can only be configured via a System Property:
 
-System Property name                         | Description                                                     | Default value
----------------------------------------------|-----------------------------------------------------------------|--------------------
-spark.mongodb.keep_alive_ms                  | The length of time to keep a MongoClient available for sharing  | 5000
+System Property name         | Description                                                     | Default value
+-----------------------------|-----------------------------------------------------------------|--------------------
+spark.mongodb.keep_alive_ms  | The length of time to keep a MongoClient available for sharing  | 5000
+
+
+The `DefaultMongoClientFactory` will can also use the following system properties when configuring the MongoClient:
+
+System Property name                  | Description                                                            | Default value
+--------------------------------------|------------------------------------------------------------------------|--------------------
+com.mongodb.updaterIntervalMS         | The frequency for determining the state of the servers in the cluster  | 10000
+com.mongodb.updaterIntervalNoMasterMS | The time to wait between re-checking a server's availability           | 500
+com.mongodb.updaterConnectTimeoutMS   | The connect timeout for connections used for the cluster heartbeat     | 20000
+com.mongodb.updaterSocketTimeoutMS    | The socket timeout for connections used for the cluster heartbeat      | 20000
+com.mongodb.slaveAcceptableLatencyMS  | The threshold for choosing a server from multiple MongoDB servers      | 15
+

--- a/doc/2-configuring.md
+++ b/doc/2-configuring.md
@@ -14,6 +14,7 @@ Property name                              | Description                        
 spark.mongodb.input.uri                    | The connnection string                                            |
 spark.mongodb.input.database               | The database name to read data from                               |
 spark.mongodb.input.collection             | The collection name to read data from                             |
+spark.mongodb.input.localThreshold         | The threshold for choosing a server from multiple MongoDB servers | 15 ms
 spark.mongodb.input.readPreference.name    | The name of the `ReadPreference` to use                           | Primary
 spark.mongodb.input.readPreference.tagSets | The `ReadPreference` TagSets to use                               |
 spark.mongodb.input.readConcern.level      | The `ReadConcern` level to use                                    |

--- a/src/main/scala/com/mongodb/spark/MongoConnector.scala
+++ b/src/main/scala/com/mongodb/spark/MongoConnector.scala
@@ -45,28 +45,22 @@ object MongoConnector {
   def apply(sparkContext: SparkContext): MongoConnector = apply(sparkContext.getConf)
 
   /**
-   * Creates a MongoConnector using the [[com.mongodb.spark.config.ReadConfig.mongoURIProperty]] from the `sparkConf`.
+   * Creates a MongoConnector using the [[com.mongodb.spark.config.ReadConfig]] from the `sparkConf`.
    *
    * @param sparkConf the Spark configuration.
    * @return the MongoConnector
    */
-  def apply(sparkConf: SparkConf): MongoConnector = {
-    require(sparkConf.contains(mongoReadURIProperty), s"Missing '$mongoReadURIProperty' property from sparkConfig")
-    MongoConnector(sparkConf.get(mongoReadURIProperty))
-  }
+  def apply(sparkConf: SparkConf): MongoConnector = apply(ReadConfig(sparkConf).asOptions)
 
   /**
    * Creates a MongoConnector
    *
-   * @param connectionString the connection string (`uri`)
+   * @param options the configuration options
    * @return the MongoConnector
    */
-  def apply(connectionString: String): MongoConnector = MongoConnector(DefaultMongoClientFactory(connectionString))
+  def apply(options: collection.Map[String, String]): MongoConnector = new MongoConnector(DefaultMongoClientFactory(options))
 
-  private[spark] val mongoReadURIProperty: String = s"${ReadConfig.configPrefix}${ReadConfig.mongoURIProperty}"
-  private[spark] val mongoWriteURIProperty: String = s"${ReadConfig.configPrefix}${ReadConfig.mongoURIProperty}"
   private[spark] val mongoClientKeepAlive = Duration(System.getProperty("spark.mongodb.keep_alive_ms", "5000").toInt, TimeUnit.MILLISECONDS)
-
   private val mongoClientCache = new MongoClientCache(mongoClientKeepAlive)
   Runtime.getRuntime.addShutdownHook(new Thread(new Runnable {
     def run() {

--- a/src/main/scala/com/mongodb/spark/api/java/MongoConnectors.scala
+++ b/src/main/scala/com/mongodb/spark/api/java/MongoConnectors.scala
@@ -19,8 +19,9 @@ package com.mongodb.spark.api.java
 import com.mongodb.spark.{MongoClientFactory, MongoConnector, notNull}
 import org.apache.spark.SparkConf
 import org.apache.spark.api.java.JavaSparkContext
-import org.apache.spark.api.java.function.{Function0 => JFunction0}
 import org.apache.spark.sql.SQLContext
+
+import scala.collection.JavaConverters._
 
 /**
  * A helper class to create a MongoConnector
@@ -65,12 +66,12 @@ object MongoConnectors {
   /**
    * Creates a MongoConnector
    *
-   * @param connectionString            the MongoClient connection string
+   * @param options the configuration options
    * @return the MongoConnector
    */
-  def create(connectionString: String): MongoConnector = {
-    notNull("connectionString", connectionString)
-    MongoConnector(connectionString)
+  def create(options: java.util.Map[String, String]): MongoConnector = {
+    notNull("options", options)
+    MongoConnector(options.asScala)
   }
 
   /**

--- a/src/main/scala/com/mongodb/spark/config/MongoClassConfig.scala
+++ b/src/main/scala/com/mongodb/spark/config/MongoClassConfig.scala
@@ -26,12 +26,12 @@ import java.util
  * @see [[ReadConfig]]
  * @since 1.0
  */
-trait MongoSparkConfig extends Serializable {
+trait MongoClassConfig extends Serializable {
 
   /**
    * Defines Self as a type that can be used to return a copy of the object i.e. a different instance of the same type
    */
-  type Self <: MongoSparkConfig
+  type Self <: MongoClassConfig
 
   /**
    * Creates a new config with the options applied

--- a/src/main/scala/com/mongodb/spark/config/MongoCompanionConfig.scala
+++ b/src/main/scala/com/mongodb/spark/config/MongoCompanionConfig.scala
@@ -29,7 +29,7 @@ import org.apache.spark.api.java.JavaSparkContext
  *
  * @since 1.0
  */
-trait MongoConfig extends Serializable {
+trait MongoCompanionConfig extends Serializable {
 
   /**
    * The type of the `MongoConfig`
@@ -43,7 +43,7 @@ trait MongoConfig extends Serializable {
    *
    * Any values set in the connection string will override any default values for the configuration.
    */
-  val mongoURIProperty = "uri"
+  val mongoURIProperty = MongoSharedConfig.mongoURIProperty
 
   /**
    * The configuration prefix string for the current configuration scope
@@ -70,7 +70,7 @@ trait MongoConfig extends Serializable {
    * @param sparkConf the spark configuration
    * @return the configuration
    */
-  def apply(sparkConf: SparkConf): Self = apply(sparkConf.getAll.filter(kv => kv._1.startsWith(configPrefix)).toMap)
+  def apply(sparkConf: SparkConf): Self = apply(sparkConf.getAll.filter(_._1.startsWith(configPrefix)).toMap)
 
   /**
    * Create a configuration from the values in the `Map`
@@ -183,7 +183,8 @@ trait MongoConfig extends Serializable {
     }
   }
 
-  protected def connectionString(options: collection.Map[String, String]) = new ConnectionString(options.getOrElse(mongoURIProperty, DefaultConnectionString))
+  protected def connectionString(options: collection.Map[String, String]) =
+    new ConnectionString(options.getOrElse(mongoURIProperty, DefaultConnectionString))
 
   private val DefaultConnectionString = "mongodb://localhost/"
 

--- a/src/main/scala/com/mongodb/spark/config/MongoInputConfig.scala
+++ b/src/main/scala/com/mongodb/spark/config/MongoInputConfig.scala
@@ -40,6 +40,7 @@ package com.mongodb.spark.config
  *  - [[sampleSizeProperty sampleSize]], the sample size to use when inferring the schema.
  *  - [[splitKeyProperty splitKey]], the partition key to split the data.
  *  - [[maxChunkSizeProperty maxChunkSize]], the maximum chunk size when partitioning data from an unsharded collection.
+ *  - [[localThresholdProperty localThreshold]], the number of milliseconds used when choosing among multiple MongoDB servers to send a request.
  *
  */
 trait MongoInputConfig extends MongoCompanionConfig {
@@ -105,13 +106,13 @@ trait MongoInputConfig extends MongoCompanionConfig {
   /**
    * The localThreshold property
    *
-   * Used when choosing among multiple MongoDB servers to send a request.
+   * The local threshold in milliseconds is used when choosing among multiple MongoDB servers to send a request.
    * Only servers whose ping time is less than or equal to the server with the fastest ping time *plus* the local threshold will be chosen.
    *
    * For example when choosing which MongoS to send a request through a `localThreshold` of 0 would pick the MongoS with the fastest ping time.
    *
-   * Default: `15`
+   * Default: `15 ms`
    */
-  val localThresholdProperty = "localThreshold".toLowerCase
+  val localThresholdProperty = MongoSharedConfig.localThresholdProperty
 
 }

--- a/src/main/scala/com/mongodb/spark/config/MongoInputConfig.scala
+++ b/src/main/scala/com/mongodb/spark/config/MongoInputConfig.scala
@@ -42,7 +42,7 @@ package com.mongodb.spark.config
  *  - [[maxChunkSizeProperty maxChunkSize]], the maximum chunk size when partitioning data from an unsharded collection.
  *
  */
-trait MongoInputConfig extends MongoConfig {
+trait MongoInputConfig extends MongoCompanionConfig {
 
   override val configPrefix = "spark.mongodb.input."
 
@@ -101,5 +101,17 @@ trait MongoInputConfig extends MongoConfig {
    * Default: `64`
    */
   val maxChunkSizeProperty = "maxChunkSize".toLowerCase
+
+  /**
+   * The localThreshold property
+   *
+   * Used when choosing among multiple MongoDB servers to send a request.
+   * Only servers whose ping time is less than or equal to the server with the fastest ping time *plus* the local threshold will be chosen.
+   *
+   * For example when choosing which MongoS to send a request through a `localThreshold` of 0 would pick the MongoS with the fastest ping time.
+   *
+   * Default: `15`
+   */
+  val localThresholdProperty = "localThreshold".toLowerCase
 
 }

--- a/src/main/scala/com/mongodb/spark/config/MongoOutputConfig.scala
+++ b/src/main/scala/com/mongodb/spark/config/MongoOutputConfig.scala
@@ -37,6 +37,7 @@ package com.mongodb.spark.config
  *  - [[writeConcernWProperty writeConcern.w]], the write concern w value.
  *  - [[writeConcernJournalProperty writeConcern.journal]], the write concern journal value.
  *  - [[writeConcernWTimeoutMSProperty writeConcern.wTimeoutMS]], the write concern wTimeout value.
+ *  - [[localThresholdProperty localThreshold]], the number of milliseconds used when choosing among multiple MongoDB servers to send a request.
  *
  */
 trait MongoOutputConfig extends MongoCompanionConfig {
@@ -73,4 +74,16 @@ trait MongoOutputConfig extends MongoCompanionConfig {
    * @see [[WriteConcernConfig]]
    */
   val writeConcernWTimeoutMSProperty = "writeConcern.wTimeoutMS".toLowerCase
+
+  /**
+   * The localThreshold property
+   *
+   * The local threshold in milliseconds is used when choosing among multiple MongoDB servers to send a request.
+   * Only servers whose ping time is less than or equal to the server with the fastest ping time *plus* the local threshold will be chosen.
+   *
+   * For example when choosing which MongoS to send a request through a `localThreshold` of 0 would pick the MongoS with the fastest ping time.
+   *
+   * Default: `15 ms`
+   */
+  val localThresholdProperty = MongoSharedConfig.localThresholdProperty
 }

--- a/src/main/scala/com/mongodb/spark/config/MongoOutputConfig.scala
+++ b/src/main/scala/com/mongodb/spark/config/MongoOutputConfig.scala
@@ -39,7 +39,7 @@ package com.mongodb.spark.config
  *  - [[writeConcernWTimeoutMSProperty writeConcern.wTimeoutMS]], the write concern wTimeout value.
  *
  */
-trait MongoOutputConfig extends MongoConfig {
+trait MongoOutputConfig extends MongoCompanionConfig {
 
   override val configPrefix = "spark.mongodb.output."
 

--- a/src/main/scala/com/mongodb/spark/config/MongoSharedConfig.scala
+++ b/src/main/scala/com/mongodb/spark/config/MongoSharedConfig.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2016 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.spark.config
+
+private[spark] object MongoSharedConfig {
+
+  val mongoURIProperty = "uri"
+
+}
+

--- a/src/main/scala/com/mongodb/spark/config/MongoSharedConfig.scala
+++ b/src/main/scala/com/mongodb/spark/config/MongoSharedConfig.scala
@@ -19,6 +19,9 @@ package com.mongodb.spark.config
 private[spark] object MongoSharedConfig {
 
   val mongoURIProperty = "uri"
+  val localThresholdProperty = "localThreshold".toLowerCase
+
+  val DefaultLocalThreshold = 15 // 15 ms
 
 }
 

--- a/src/main/scala/com/mongodb/spark/config/ReadConcernConfig.scala
+++ b/src/main/scala/com/mongodb/spark/config/ReadConcernConfig.scala
@@ -18,6 +18,8 @@ package com.mongodb.spark.config
 
 import java.util
 
+import com.mongodb.spark.notNull
+
 import scala.collection.JavaConverters._
 import scala.collection.Map
 import scala.util.Try
@@ -73,15 +75,31 @@ object ReadConcernConfig extends MongoInputConfig {
    * @param readConcern the read concern
    * @return the configuration
    */
-  def create(readConcern: ReadConcern): ReadConcernConfig = apply(readConcern)
+  def create(readConcern: ReadConcern): ReadConcernConfig = {
+    notNull("readConcern", readConcern)
+    apply(readConcern)
+  }
 
-  override def create(sparkConf: SparkConf): ReadConcernConfig = apply(sparkConf)
+  override def create(sparkConf: SparkConf): ReadConcernConfig = {
+    notNull("sparkConf", sparkConf)
+    apply(sparkConf)
+  }
 
-  override def create(options: util.Map[String, String]): ReadConcernConfig = apply(options.asScala, None)
+  override def create(options: util.Map[String, String]): ReadConcernConfig = {
+    notNull("options", options)
+    apply(options.asScala)
+  }
 
-  override def create(options: util.Map[String, String], default: ReadConcernConfig): ReadConcernConfig = apply(options.asScala, Option(default))
+  override def create(options: util.Map[String, String], default: ReadConcernConfig): ReadConcernConfig = {
+    notNull("options", options)
+    notNull("default", default)
+    apply(options.asScala, Some(default))
+  }
 
-  override def create(javaSparkContext: JavaSparkContext): ReadConcernConfig = ???
+  override def create(javaSparkContext: JavaSparkContext): ReadConcernConfig = {
+    notNull("javaSparkContext", javaSparkContext)
+    apply(javaSparkContext.getConf)
+  }
 }
 
 /**
@@ -90,7 +108,7 @@ object ReadConcernConfig extends MongoInputConfig {
  * @param readConcernLevel the optional read concern level. If None the servers default level will be used.
  * @since 1.0
  */
-case class ReadConcernConfig(private val readConcernLevel: Option[String] = None) extends MongoSparkConfig {
+case class ReadConcernConfig(private val readConcernLevel: Option[String] = None) extends MongoClassConfig {
   require(Try(readConcern).isSuccess, s"Invalid ReadConcernConfig configuration")
 
   type Self = ReadConcernConfig

--- a/src/main/scala/com/mongodb/spark/config/ReadConfig.scala
+++ b/src/main/scala/com/mongodb/spark/config/ReadConfig.scala
@@ -39,7 +39,6 @@ object ReadConfig extends MongoInputConfig {
   private val DefaultSampleSize: Int = 1000
   private val DefaultMaxChunkSize = 64 // 64 MB
   private val DefaultSplitKey = "_id"
-  private val DefaultLocalThreshold = 15 // 15MS
 
   override def apply(options: collection.Map[String, String], default: Option[ReadConfig]): ReadConfig = {
     val cleanedOptions = prefixLessOptions(options)
@@ -50,7 +49,8 @@ object ReadConfig extends MongoInputConfig {
       sampleSize = getInt(cleanedOptions.get(sampleSizeProperty), default.map(conf => conf.sampleSize), DefaultSampleSize),
       maxChunkSize = getInt(cleanedOptions.get(maxChunkSizeProperty), default.map(conf => conf.maxChunkSize), DefaultMaxChunkSize),
       splitKey = getString(cleanedOptions.get(splitKeyProperty), default.map(conf => conf.splitKey), DefaultSplitKey),
-      localThreshold = getInt(cleanedOptions.get(localThresholdProperty), default.map(conf => conf.localThreshold), DefaultLocalThreshold),
+      localThreshold = getInt(cleanedOptions.get(localThresholdProperty), default.map(conf => conf.localThreshold),
+        MongoSharedConfig.DefaultLocalThreshold),
       readPreferenceConfig = ReadPreferenceConfig(cleanedOptions, default.map(conf => conf.readPreferenceConfig)),
       readConcernConfig = ReadConcernConfig(cleanedOptions, default.map(conf => conf.readConcernConfig))
     )
@@ -66,9 +66,9 @@ object ReadConfig extends MongoInputConfig {
    * @param sampleSize a positive integer sample size to draw from the collection when inferring the schema
    * @param maxChunkSize   the maximum chunkSize for non-sharded collections
    * @param splitKey the key to split the collection by for non-sharded collections or the "shard key" for sharded collection
-   * @param localThreshold the local threshold is used when choosing among multiple MongoDB servers to send a request. Only servers
-   *                       whose ping time is less than or equal to the server with the fastest ping time plus the local threshold will be
-   *                       chosen.
+   * @param localThreshold the local threshold in milliseconds used when choosing among multiple MongoDB servers to send a request.
+   *                       Only servers whose ping time is less than or equal to the server with the fastest ping time plus the local
+   *                       threshold will be chosen.
    * @param readPreference the readPreference configuration
    * @param readConcern the readConcern configuration
    *
@@ -119,9 +119,9 @@ object ReadConfig extends MongoInputConfig {
  * @param sampleSize a positive integer sample size to draw from the collection when inferring the schema
  * @param maxChunkSize   the maximum chunkSize for non-sharded collections
  * @param splitKey the key to split the collection by for non-sharded collections or the "shard key" for sharded collection
- * @param localThreshold the local threshold is used when choosing among multiple MongoDB servers to send a request. Only servers
- *                       whose ping time is less than or equal to the server with the fastest ping time plus the local threshold will be
- *                       chosen.
+ * @param localThreshold the local threshold in milliseconds used when choosing among multiple MongoDB servers to send a request.
+ *                       Only servers whose ping time is less than or equal to the server with the fastest ping time plus the local
+ *                       threshold will be chosen.
  * @param readPreferenceConfig the readPreference configuration
  * @param readConcernConfig the readConcern configuration
  *
@@ -134,7 +134,7 @@ case class ReadConfig(
     sampleSize:           Int                  = ReadConfig.DefaultSampleSize,
     maxChunkSize:         Int                  = ReadConfig.DefaultMaxChunkSize,
     splitKey:             String               = ReadConfig.DefaultSplitKey,
-    localThreshold:       Int                  = ReadConfig.DefaultLocalThreshold,
+    localThreshold:       Int                  = MongoSharedConfig.DefaultLocalThreshold,
     readPreferenceConfig: ReadPreferenceConfig = ReadPreferenceConfig(),
     readConcernConfig:    ReadConcernConfig    = ReadConcernConfig()
 ) extends MongoCollectionConfig with MongoClassConfig {

--- a/src/main/scala/com/mongodb/spark/config/ReadConfig.scala
+++ b/src/main/scala/com/mongodb/spark/config/ReadConfig.scala
@@ -18,10 +18,12 @@ package com.mongodb.spark.config
 
 import java.util
 
-import scala.collection.JavaConverters._
-import org.apache.spark.SparkConf
+import com.mongodb.spark.notNull
 import com.mongodb.{ReadConcern, ReadPreference}
+import org.apache.spark.SparkConf
 import org.apache.spark.api.java.JavaSparkContext
+
+import scala.collection.JavaConverters._
 
 /**
  * The `ReadConfig` companion object
@@ -37,27 +39,74 @@ object ReadConfig extends MongoInputConfig {
   private val DefaultSampleSize: Int = 1000
   private val DefaultMaxChunkSize = 64 // 64 MB
   private val DefaultSplitKey = "_id"
+  private val DefaultLocalThreshold = 15 // 15MS
 
   override def apply(options: collection.Map[String, String], default: Option[ReadConfig]): ReadConfig = {
     val cleanedOptions = prefixLessOptions(options)
     ReadConfig(
       databaseName = databaseName(databaseNameProperty, cleanedOptions, default.map(conf => conf.databaseName)),
       collectionName = collectionName(collectionNameProperty, cleanedOptions, default.map(conf => conf.collectionName)),
+      connectionString = cleanedOptions.get(mongoURIProperty).orElse(default.flatMap(conf => conf.connectionString)),
       sampleSize = getInt(cleanedOptions.get(sampleSizeProperty), default.map(conf => conf.sampleSize), DefaultSampleSize),
       maxChunkSize = getInt(cleanedOptions.get(maxChunkSizeProperty), default.map(conf => conf.maxChunkSize), DefaultMaxChunkSize),
       splitKey = getString(cleanedOptions.get(splitKeyProperty), default.map(conf => conf.splitKey), DefaultSplitKey),
+      localThreshold = getInt(cleanedOptions.get(localThresholdProperty), default.map(conf => conf.localThreshold), DefaultLocalThreshold),
       readPreferenceConfig = ReadPreferenceConfig(cleanedOptions, default.map(conf => conf.readPreferenceConfig)),
       readConcernConfig = ReadConcernConfig(cleanedOptions, default.map(conf => conf.readConcernConfig))
     )
   }
 
-  override def create(javaSparkContext: JavaSparkContext): ReadConfig = apply(javaSparkContext.getConf)
+  // scalastyle:off parameter.number
+  /**
+   * Read Configuration used when reading data from MongoDB
+   *
+   * @param databaseName the database name
+   * @param collectionName the collection name
+   * @param connectionString the optional connection string used in the creation of this configuration
+   * @param sampleSize a positive integer sample size to draw from the collection when inferring the schema
+   * @param maxChunkSize   the maximum chunkSize for non-sharded collections
+   * @param splitKey the key to split the collection by for non-sharded collections or the "shard key" for sharded collection
+   * @param localThreshold the local threshold is used when choosing among multiple MongoDB servers to send a request. Only servers
+   *                       whose ping time is less than or equal to the server with the fastest ping time plus the local threshold will be
+   *                       chosen.
+   * @param readPreference the readPreference configuration
+   * @param readConcern the readConcern configuration
+   *
+   * @since 1.0
+   */
+  def create(databaseName: String, collectionName: String, connectionString: String, sampleSize: Int, maxChunkSize: Int, splitKey: String,
+             localThreshold: Int, readPreference: ReadPreference, readConcern: ReadConcern): ReadConfig = {
+    notNull("databaseName", databaseName)
+    notNull("collectionName", collectionName)
+    notNull("splitKey", splitKey)
+    notNull("readPreference", readPreference)
+    notNull("readConcern", readConcern)
 
-  override def create(sparkConf: SparkConf): ReadConfig = apply(sparkConf)
+    new ReadConfig(databaseName, collectionName, Option(connectionString), sampleSize, maxChunkSize, splitKey, localThreshold,
+      ReadPreferenceConfig.apply(readPreference), ReadConcernConfig.apply(readConcern))
+  }
+  // scalastyle:on parameter.number
 
-  override def create(options: util.Map[String, String]): ReadConfig = apply(options.asScala)
+  override def create(javaSparkContext: JavaSparkContext): ReadConfig = {
+    notNull("javaSparkContext", javaSparkContext)
+    apply(javaSparkContext.getConf)
+  }
 
-  override def create(options: util.Map[String, String], default: ReadConfig): ReadConfig = apply(options.asScala, Option(default))
+  override def create(sparkConf: SparkConf): ReadConfig = {
+    notNull("sparkConf", sparkConf)
+    apply(sparkConf)
+  }
+
+  override def create(options: util.Map[String, String]): ReadConfig = {
+    notNull("options", options)
+    apply(options.asScala)
+  }
+
+  override def create(options: util.Map[String, String], default: ReadConfig): ReadConfig = {
+    notNull("options", options)
+    notNull("default", default)
+    apply(options.asScala, Option(default))
+  }
 
 }
 
@@ -66,9 +115,13 @@ object ReadConfig extends MongoInputConfig {
  *
  * @param databaseName the database name
  * @param collectionName the collection name
+ * @param connectionString the optional connection string used in the creation of this configuration
  * @param sampleSize a positive integer sample size to draw from the collection when inferring the schema
  * @param maxChunkSize   the maximum chunkSize for non-sharded collections
  * @param splitKey the key to split the collection by for non-sharded collections or the "shard key" for sharded collection
+ * @param localThreshold the local threshold is used when choosing among multiple MongoDB servers to send a request. Only servers
+ *                       whose ping time is less than or equal to the server with the fastest ping time plus the local threshold will be
+ *                       chosen.
  * @param readPreferenceConfig the readPreference configuration
  * @param readConcernConfig the readConcern configuration
  *
@@ -77,26 +130,35 @@ object ReadConfig extends MongoInputConfig {
 case class ReadConfig(
     databaseName:         String,
     collectionName:       String,
+    connectionString:     Option[String]       = None,
     sampleSize:           Int                  = ReadConfig.DefaultSampleSize,
     maxChunkSize:         Int                  = ReadConfig.DefaultMaxChunkSize,
     splitKey:             String               = ReadConfig.DefaultSplitKey,
+    localThreshold:       Int                  = ReadConfig.DefaultLocalThreshold,
     readPreferenceConfig: ReadPreferenceConfig = ReadPreferenceConfig(),
     readConcernConfig:    ReadConcernConfig    = ReadConcernConfig()
-) extends MongoCollectionConfig with MongoSparkConfig {
+) extends MongoCollectionConfig with MongoClassConfig {
   require(sampleSize > 0, s"sampleSize ($sampleSize) must be greater than 0")
+  require(localThreshold >= 0, s"localThreshold ($localThreshold) must be greater or equal to 0")
 
   type Self = ReadConfig
 
   override def withOptions(options: collection.Map[String, String]): ReadConfig = ReadConfig(options, Some(this))
 
   override def asOptions: collection.Map[String, String] = {
-    Map(
+    val options = Map(
       ReadConfig.databaseNameProperty -> databaseName,
       ReadConfig.collectionNameProperty -> collectionName,
       ReadConfig.sampleSizeProperty -> sampleSize.toString,
       ReadConfig.maxChunkSizeProperty -> maxChunkSize.toString,
-      ReadConfig.splitKeyProperty -> splitKey
+      ReadConfig.splitKeyProperty -> splitKey,
+      ReadConfig.localThresholdProperty -> localThreshold.toString
     ) ++ readPreferenceConfig.asOptions ++ readConcernConfig.asOptions
+
+    connectionString match {
+      case Some(uri) => options + (ReadConfig.mongoURIProperty -> uri)
+      case None      => options
+    }
   }
 
   override def withJavaOptions(options: util.Map[String, String]): ReadConfig = withOptions(options.asScala)

--- a/src/main/scala/com/mongodb/spark/config/WriteConcernConfig.scala
+++ b/src/main/scala/com/mongodb/spark/config/WriteConcernConfig.scala
@@ -116,7 +116,7 @@ object WriteConcernConfig extends MongoOutputConfig {
  */
 case class WriteConcernConfig(private val w: Option[Int] = None, private val wName: Option[String] = None,
                               private val journal:  Option[Boolean]  = None,
-                              private val wTimeout: Option[Duration] = None) extends MongoSparkConfig {
+                              private val wTimeout: Option[Duration] = None) extends MongoClassConfig {
 
   require(Try(writeConcern).isSuccess, s"Invalid WriteConcernConfig configuration: $this")
 

--- a/src/main/scala/com/mongodb/spark/sql/DefaultSource.scala
+++ b/src/main/scala/com/mongodb/spark/sql/DefaultSource.scala
@@ -16,22 +16,20 @@
 
 package com.mongodb.spark.sql
 
-import scala.collection.JavaConverters._
-
-import org.apache.spark.SparkConf
-import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.SaveMode._
-import org.apache.spark.sql.sources._
-import org.apache.spark.sql.types.StructType
-import org.apache.spark.sql.{DataFrame, SQLContext, SaveMode}
-
-import org.bson.conversions.Bson
-import org.bson.{BsonArray, BsonDocument, BsonType, Document}
 import com.mongodb.client.MongoCollection
 import com.mongodb.spark.config.{ReadConfig, WriteConfig}
 import com.mongodb.spark.rdd.MongoRDD
 import com.mongodb.spark.sql.MongoRelationHelper._
 import com.mongodb.spark.{MongoConnector, toDocumentRDDFunctions}
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.SaveMode._
+import org.apache.spark.sql.sources._
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.{DataFrame, SQLContext, SaveMode}
+import org.bson.conversions.Bson
+import org.bson.{BsonArray, BsonDocument, BsonType, Document}
+
+import scala.collection.JavaConverters._
 
 /**
  * A MongoDB based DataSource
@@ -126,18 +124,12 @@ class DefaultSource extends DataSourceRegister with RelationProvider with Schema
   }
 
   private def connectorAndReadConfig(sqlContext: SQLContext, parameters: Map[String, String]): (MongoConnector, ReadConfig) = {
-    val sparkConf: SparkConf = sqlContext.sparkContext.getConf
-    val uri: String = parameters.getOrElse("uri", sparkConf.get(MongoConnector.mongoReadURIProperty))
-    val mongoConnector: MongoConnector = MongoConnector(uri)
-    val readConfig: ReadConfig = ReadConfig(sparkConf).withOptions(parameters)
-    (mongoConnector, readConfig)
+    val readConfig = ReadConfig(sqlContext.sparkContext.getConf).withOptions(parameters)
+    (MongoConnector(readConfig.asOptions), readConfig)
   }
 
   private def connectorAndWriteConfig(sqlContext: SQLContext, parameters: Map[String, String]): (MongoConnector, WriteConfig) = {
-    val sparkConf: SparkConf = sqlContext.sparkContext.getConf
-    val uri: String = parameters.getOrElse("uri", sparkConf.get(MongoConnector.mongoWriteURIProperty))
-    val mongoConnector: MongoConnector = MongoConnector(uri)
-    val writeConfig: WriteConfig = WriteConfig(sparkConf).withOptions(parameters)
-    (mongoConnector, writeConfig)
+    val writeConfig = WriteConfig(sqlContext.sparkContext.getConf).withOptions(parameters)
+    (MongoConnector(writeConfig.asOptions), writeConfig)
   }
 }

--- a/src/main/scala/com/mongodb/spark/sql/SparkSQLContextFunctions.scala
+++ b/src/main/scala/com/mongodb/spark/sql/SparkSQLContextFunctions.scala
@@ -34,7 +34,7 @@ import com.mongodb.spark.rdd.MongoRDD
  * @param sqlContext the SQLContext
  * @since 1.0
  */
-case class SparkSQLContextFunctions(@transient val sqlContext: SQLContext) extends Serializable {
+case class SparkSQLContextFunctions(@transient sqlContext: SQLContext) extends Serializable {
 
   @transient private val sc: SparkContext = sqlContext.sparkContext
   @transient private val sparkConf: SparkConf = sc.getConf

--- a/src/test/java/com/mongodb/spark/api/java/MongoConnectorTest.java
+++ b/src/test/java/com/mongodb/spark/api/java/MongoConnectorTest.java
@@ -19,7 +19,9 @@ package com.mongodb.spark.api.java;
 import com.mongodb.MongoClient;
 import com.mongodb.spark.MongoClientFactory;
 import com.mongodb.spark.MongoConnector;
+import com.mongodb.spark.config.ReadConfig;
 import com.mongodb.spark.connection.DefaultMongoClientFactory;
+import org.apache.spark.SparkConf;
 import org.junit.Test;
 import scala.runtime.AbstractFunction1;
 
@@ -29,7 +31,7 @@ public final class MongoConnectorTest extends RequiresMongoDB {
 
     @Test
     public void shouldCreateMongoConnector() {
-        MongoConnector mongoConnector = MongoConnectors.create(getMongoClientURI());
+        MongoConnector mongoConnector = MongoConnectors.create(getSparkConf());
         Boolean created = mongoConnector.withMongoClientDo(new AbstractFunction1<MongoClient, Boolean>() {
             @Override
             public Boolean apply(final MongoClient v1) {
@@ -42,10 +44,10 @@ public final class MongoConnectorTest extends RequiresMongoDB {
 
     @Test
     public void shouldUseTheMongoClientCache() {
-        Boolean sameClient = MongoConnectors.create(getMongoClientURI()).withMongoClientDo(new AbstractFunction1<MongoClient, Boolean>() {
+        Boolean sameClient = MongoConnectors.create(getSparkConf()).withMongoClientDo(new AbstractFunction1<MongoClient, Boolean>() {
             @Override
             public Boolean apply(final MongoClient client1) {
-                return MongoConnectors.create(getMongoClientURI()).withMongoClientDo(new AbstractFunction1<MongoClient, Boolean>() {
+                return MongoConnectors.create(getSparkConf()).withMongoClientDo(new AbstractFunction1<MongoClient, Boolean>() {
                     @Override
                     public Boolean apply(final MongoClient client2) {
                         return client1.equals(client2);
@@ -71,7 +73,7 @@ public final class MongoConnectorTest extends RequiresMongoDB {
 
     @Test
     public void shouldCreateMongoConnectorWithCustomMongoClientFactory() {
-        MongoConnector mongoConnector = MongoConnectors.create(new JavaMongoClientFactory(getMongoClientURI()));
+        MongoConnector mongoConnector = MongoConnectors.create(new JavaMongoClientFactory(getSparkConf()));
         Boolean created = mongoConnector.withMongoClientDo(new AbstractFunction1<MongoClient, Boolean>() {
             @Override
             public Boolean apply(final MongoClient v1) {
@@ -85,8 +87,8 @@ public final class MongoConnectorTest extends RequiresMongoDB {
     class JavaMongoClientFactory implements MongoClientFactory {
         private final DefaultMongoClientFactory proxy;
 
-        JavaMongoClientFactory(final String connectionString) {
-            this.proxy = new DefaultMongoClientFactory(connectionString);
+        JavaMongoClientFactory(final SparkConf sparkConf) {
+            this.proxy = DefaultMongoClientFactory.apply(ReadConfig.create(sparkConf).asOptions());
         }
 
         @Override

--- a/src/test/java/com/mongodb/spark/api/java/config/WriteConfigTest.java
+++ b/src/test/java/com/mongodb/spark/api/java/config/WriteConfigTest.java
@@ -30,10 +30,13 @@ import static org.junit.Assert.assertEquals;
 
 public final class WriteConfigTest extends RequiresMongoDB {
 
+    private final int localThreshold = 15;
+
     @Test
     public void shouldBeCreatableFromTheSparkConf() {
         WriteConfig readConfig = WriteConfig.create(getSparkConf());
-        WriteConfig expectedReadConfig = WriteConfig.create(getDatabaseName(), getCollectionName(), getMongoClientURI(), WriteConcern.ACKNOWLEDGED);
+        WriteConfig expectedReadConfig = WriteConfig.create(getDatabaseName(), getCollectionName(), localThreshold, getMongoClientURI(),
+                WriteConcern.ACKNOWLEDGED);
 
         assertEquals(readConfig, expectedReadConfig);
     }
@@ -43,12 +46,13 @@ public final class WriteConfigTest extends RequiresMongoDB {
         Map<String, String> options = new HashMap<String, String>();
         options.put(WriteConfig.databaseNameProperty(), "db");
         options.put(WriteConfig.collectionNameProperty(), "collection");
+        options.put(WriteConfig.localThresholdProperty(), "5");
         options.put(WriteConfig.writeConcernWProperty(), "1");
         options.put(WriteConfig.writeConcernJournalProperty(), "true");
         options.put(WriteConfig.writeConcernWTimeoutMSProperty(), "100");
 
         WriteConfig writeConfig = WriteConfig.create(options);
-        WriteConfig expectedWriteConfig = WriteConfig.create("db", "collection", null,
+        WriteConfig expectedWriteConfig = WriteConfig.create("db", "collection", 5, null,
                 WriteConcern.W1.withJournal(true).withWTimeout(100, TimeUnit.MILLISECONDS));
 
         assertEquals(writeConfig, expectedWriteConfig);
@@ -61,7 +65,7 @@ public final class WriteConfigTest extends RequiresMongoDB {
         options.put(ReadConfig.collectionNameProperty(), "collection");
 
         WriteConfig writeConfig = WriteConfig.create(options, WriteConfig.create(getSparkConf()));
-        WriteConfig expectedWriteConfig = WriteConfig.create("db", "collection", getMongoClientURI(), WriteConcern.ACKNOWLEDGED);
+        WriteConfig expectedWriteConfig = WriteConfig.create("db", "collection", localThreshold, getMongoClientURI(), WriteConcern.ACKNOWLEDGED);
 
         assertEquals(writeConfig, expectedWriteConfig);
     }

--- a/src/test/java/com/mongodb/spark/api/java/config/WriteConfigTest.java
+++ b/src/test/java/com/mongodb/spark/api/java/config/WriteConfigTest.java
@@ -19,7 +19,6 @@ package com.mongodb.spark.api.java.config;
 import com.mongodb.WriteConcern;
 import com.mongodb.spark.api.java.RequiresMongoDB;
 import com.mongodb.spark.config.ReadConfig;
-import com.mongodb.spark.config.WriteConcernConfig;
 import com.mongodb.spark.config.WriteConfig;
 import org.junit.Test;
 
@@ -30,10 +29,11 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.Assert.assertEquals;
 
 public final class WriteConfigTest extends RequiresMongoDB {
+
     @Test
     public void shouldBeCreatableFromTheSparkConf() {
         WriteConfig readConfig = WriteConfig.create(getSparkConf());
-        WriteConfig expectedReadConfig = new WriteConfig(getDatabaseName(), getCollectionName(), WriteConcernConfig.create(getSparkConf()));
+        WriteConfig expectedReadConfig = WriteConfig.create(getDatabaseName(), getCollectionName(), getMongoClientURI(), WriteConcern.ACKNOWLEDGED);
 
         assertEquals(readConfig, expectedReadConfig);
     }
@@ -48,8 +48,8 @@ public final class WriteConfigTest extends RequiresMongoDB {
         options.put(WriteConfig.writeConcernWTimeoutMSProperty(), "100");
 
         WriteConfig writeConfig = WriteConfig.create(options);
-        WriteConfig expectedWriteConfig = new WriteConfig("db", "collection",
-                WriteConcernConfig.create(WriteConcern.W1.withJournal(true).withWTimeout(100, TimeUnit.MILLISECONDS)));
+        WriteConfig expectedWriteConfig = WriteConfig.create("db", "collection", null,
+                WriteConcern.W1.withJournal(true).withWTimeout(100, TimeUnit.MILLISECONDS));
 
         assertEquals(writeConfig, expectedWriteConfig);
     }
@@ -61,8 +61,7 @@ public final class WriteConfigTest extends RequiresMongoDB {
         options.put(ReadConfig.collectionNameProperty(), "collection");
 
         WriteConfig writeConfig = WriteConfig.create(options, WriteConfig.create(getSparkConf()));
-        WriteConfig expectedWriteConfig = new WriteConfig("db", "collection",
-                WriteConcernConfig.create(WriteConcern.ACKNOWLEDGED));
+        WriteConfig expectedWriteConfig = WriteConfig.create("db", "collection", getMongoClientURI(), WriteConcern.ACKNOWLEDGED);
 
         assertEquals(writeConfig, expectedWriteConfig);
     }

--- a/src/test/scala/com/mongodb/spark/MongoDBDefaults.scala
+++ b/src/test/scala/com/mongodb/spark/MongoDBDefaults.scala
@@ -52,6 +52,7 @@ class MongoDBDefaults extends Logging {
       .set("spark.mongodb.input.uri", mongoClientURI)
       .set("spark.mongodb.input.database", DATABASE_NAME)
       .set("spark.mongodb.input.collection", collectionName)
+      .set("spark.mongodb.output.uri", mongoClientURI)
       .set("spark.mongodb.output.database", DATABASE_NAME)
       .set("spark.mongodb.output.collection", collectionName)
   }

--- a/src/test/scala/com/mongodb/spark/RequiresMongoDB.scala
+++ b/src/test/scala/com/mongodb/spark/RequiresMongoDB.scala
@@ -74,7 +74,7 @@ trait RequiresMongoDB extends FlatSpec with Matchers with BeforeAndAfterAll with
 
   def loadSampleData(sizeInMB: Int): Unit = mongoDBDefaults.loadSampleData(readConfig.collectionName, sizeInMB)
 
-  def mongoConnector: MongoConnector = MongoConnector(mongoClientURI)
+  def mongoConnector: MongoConnector = MongoConnector(sparkConf)
 
   def sparkConf: SparkConf = sparkConf(collectionName)
 

--- a/src/test/scala/com/mongodb/spark/config/WriteConfigSpec.scala
+++ b/src/test/scala/com/mongodb/spark/config/WriteConfigSpec.scala
@@ -29,14 +29,14 @@ import com.mongodb.WriteConcern
 class WriteConfigSpec extends FlatSpec with Matchers {
 
   "WriteConfig" should "have the expected defaults" in {
-    val expectedWriteConfig = WriteConfig("db", "collection", WriteConcern.ACKNOWLEDGED)
+    val expectedWriteConfig = WriteConfig("db", "collection", MongoSharedConfig.DefaultLocalThreshold, WriteConcern.ACKNOWLEDGED)
 
     WriteConfig("db", "collection") should equal(expectedWriteConfig)
   }
 
   it should "be creatable from SparkConfig" in {
     forAll(writeConcerns) { writeConcern: WriteConcern =>
-      val expectedWriteConfig = WriteConfig("db", "collection", writeConcern)
+      val expectedWriteConfig = WriteConfig("db", "collection", MongoSharedConfig.DefaultLocalThreshold, writeConcern)
 
       val conf = sparkConf.clone()
       Option(writeConcern.getWObject).map(w => conf.set(s"${WriteConfig.configPrefix}${WriteConfig.writeConcernWProperty}", w.toString))
@@ -50,9 +50,10 @@ class WriteConfigSpec extends FlatSpec with Matchers {
 
   it should "round trip options" in {
     val uri = "mongodb://localhost/"
-    val defaultWriteConfig = WriteConfig("dbName", "collName", uri, WriteConcern.ACKNOWLEDGED)
+    val localThreshold = 5
+    val defaultWriteConfig = WriteConfig("dbName", "collName", localThreshold, uri, WriteConcern.ACKNOWLEDGED)
     forAll(writeConcerns) { writeConcern: WriteConcern =>
-      val expectedWriteConfig = WriteConfig("db", "collection", uri, writeConcern)
+      val expectedWriteConfig = WriteConfig("db", "collection", localThreshold, uri, writeConcern)
       defaultWriteConfig.withOptions(expectedWriteConfig.asOptions) should equal(expectedWriteConfig)
     }
   }

--- a/src/test/scala/com/mongodb/spark/config/WriteConfigSpec.scala
+++ b/src/test/scala/com/mongodb/spark/config/WriteConfigSpec.scala
@@ -49,9 +49,10 @@ class WriteConfigSpec extends FlatSpec with Matchers {
   }
 
   it should "round trip options" in {
-    val defaultWriteConfig = WriteConfig("dbName", "collName", WriteConcern.ACKNOWLEDGED)
+    val uri = "mongodb://localhost/"
+    val defaultWriteConfig = WriteConfig("dbName", "collName", uri, WriteConcern.ACKNOWLEDGED)
     forAll(writeConcerns) { writeConcern: WriteConcern =>
-      val expectedWriteConfig = WriteConfig("db", "collection", writeConcern)
+      val expectedWriteConfig = WriteConfig("db", "collection", uri, writeConcern)
       defaultWriteConfig.withOptions(expectedWriteConfig.asOptions) should equal(expectedWriteConfig)
     }
   }

--- a/src/test/scala/com/mongodb/spark/connection/DefaultMongoClientFactorySpec.scala
+++ b/src/test/scala/com/mongodb/spark/connection/DefaultMongoClientFactorySpec.scala
@@ -18,24 +18,32 @@ package com.mongodb.spark.connection
 
 import com.mongodb.MongoClient
 import com.mongodb.spark.RequiresMongoDB
+import com.mongodb.spark.config.ReadConfig
 
 class DefaultMongoClientFactorySpec extends RequiresMongoDB {
 
   "DefaultMongoClientFactory" should "create a MongoClient from the connection string" in {
-    val client = DefaultMongoClientFactory(mongoClientURI).create()
+    val client = DefaultMongoClientFactory(ReadConfig(sparkConf).asOptions).create()
     client shouldBe a[MongoClient]
     client.close()
   }
 
-  it should "implement equals based on the connection string" in {
-    val factory1 = DefaultMongoClientFactory(mongoClientURI)
-    val factory2 = DefaultMongoClientFactory(mongoClientURI)
+  it should "implement equals based on the prefix less options map" in {
+    val factory1 = DefaultMongoClientFactory(ReadConfig(sparkConf).asOptions)
+    val factory2 = DefaultMongoClientFactory(ReadConfig(sparkConf).asOptions)
 
     factory1 should equal(factory2)
   }
 
+  it should "set the localThreshold correctly" in {
+    val conf = sparkConf.clone().set(s"${ReadConfig.configPrefix}${ReadConfig.localThresholdProperty}", "0")
+    val client = DefaultMongoClientFactory(ReadConfig(conf).asOptions).create()
+
+    client.getMongoClientOptions.getLocalThreshold should equal(0)
+  }
+
   it should "validate the connection string" in {
-    an[IllegalArgumentException] should be thrownBy new DefaultMongoClientFactory("invalid connection string")
+    an[IllegalArgumentException] should be thrownBy DefaultMongoClientFactory(Map("uri" -> "invalid connection string"))
   }
 
 }

--- a/src/test/scala/com/mongodb/spark/connection/MongoClientCacheSpec.scala
+++ b/src/test/scala/com/mongodb/spark/connection/MongoClientCacheSpec.scala
@@ -19,11 +19,10 @@ package com.mongodb.spark.connection
 import java.util.concurrent.TimeUnit
 
 import scala.concurrent.duration.Duration
-
 import org.scalamock.scalatest.proxy.MockFactory
-
 import com.mongodb.Implicits._
 import com.mongodb.spark.RequiresMongoDB
+import com.mongodb.spark.config.ReadConfig
 
 class MongoClientCacheSpec extends RequiresMongoDB with MockFactory {
 
@@ -31,7 +30,8 @@ class MongoClientCacheSpec extends RequiresMongoDB with MockFactory {
   val longDuration = Duration(1, TimeUnit.MINUTES)
   val keepAlive = Duration(250, TimeUnit.MILLISECONDS) // scalastyle:off
   val clientCache = new MongoClientCache(keepAlive)
-  val clientFactory = DefaultMongoClientFactory(mongoClientURI)
+  val clientFactory = DefaultMongoClientFactory(ReadConfig(sparkConf).asOptions)
+  val clientFactory2 = DefaultMongoClientFactory(ReadConfig(sparkConf).asOptions)
 
   "MongoClientCache" should "create a client and then close the client once released" in {
     val client = clientCache.acquire(clientFactory)
@@ -49,7 +49,7 @@ class MongoClientCacheSpec extends RequiresMongoDB with MockFactory {
 
   it should "return a different client once released " in {
     val client = clientCache.acquire(clientFactory)
-    val client2 = clientCache.acquire(clientFactory)
+    val client2 = clientCache.acquire(clientFactory2)
 
     client2 should be theSameInstanceAs client
 


### PR DESCRIPTION
As its required when creating the MongoClient, it means the configuration has
to be passed to the DefaultMongoClientFactory.

MongoConnector now takes an options map so localThreshold can be passed to the DefaultMongoClientFactory.
The ReadConfig and WriteConfig have been refactored so they can optionally include the URI. Allowing for
easy creation of a Read or Write MongoConnector.

SPARK-29