### PR TITLE
MongoSpark, MongoRDD and MongoPartitioner improvements

### DIFF
--- a/doc/0-introduction.md
+++ b/doc/0-introduction.md
@@ -140,4 +140,9 @@ Any aggregation pipeline is valid, pre aggregating data in MongoDB may be more p
 
 -----
 
+## MongoSpark
+
+If you require granular control over your configuration, then the `MongoSpark` companion provides a `builder()` method for configuring 
+all aspects of the Mongo Spark Connector.  It also provides easy methods for going on to create an `RDD`, `DataFrame` or `Dataset`.
+
 [Next - Spark SQL](1-sparkSQL.md)

--- a/doc/1-sparkSQL.md
+++ b/doc/1-sparkSQL.md
@@ -45,7 +45,7 @@ First enable the Mongo Connector specific functions on the `SQLContext`:
 import com.mongodb.spark.sql._
 ```
 
-### DataFrames and DataSets
+### DataFrames and Datasets
 
 Creating a DataFrame is easy using the implicit `mongo` helper on the `DataFrameReader`:
 
@@ -115,15 +115,15 @@ root
 
 ```
 
-The following example converts the `DataFrame` into a `DataSet`:
+The following example converts the `DataFrame` into a `Dataset`:
 
 ```scala
 explicitDF.as[Character]
 ```
 
-#### RDD to DataFrame / DataSets
+#### RDD to DataFrame / Datasets
 
-The `MongoRDD` class provides helpers to create DataFrames and DataSets directly:
+The `MongoRDD` class provides helpers to create DataFrames and Datasets directly:
 
 ```scala
 val dataframeInferred = sqlContext.loadFromMongoDB().toDF()
@@ -186,7 +186,7 @@ Outputs:
 ## DataTypes
 
 Spark supports a limited number of data types, to ensure that all bson types can be round tripped in and out of Spark DataFrames / 
-DataSets. Custom StructTypes are created for any unsupported Bson Types. The following table shows the mapping between the Bson Types and 
+Datasets. Custom StructTypes are created for any unsupported Bson Types. The following table shows the mapping between the Bson Types and 
 Spark Types:
 
 Bson Type               | Spark Type
@@ -214,7 +214,7 @@ Bson Type               | Spark Type
 
 ### Dataset support
 
-To help better support DataSets, the following Scala case classes and JavaBean classes have been created to represent the unsupported Bson 
+To help better support Datasets, the following Scala case classes and JavaBean classes have been created to represent the unsupported Bson 
 Types:
 
 Bson Type               | Scala case class                       | JavaBean

--- a/doc/3-java-api.md
+++ b/doc/3-java-api.md
@@ -107,7 +107,7 @@ System.out.println(aggregatedRdd.count());
 System.out.println(aggregatedRdd.first().toJson());
 ```
 
-## DataFrames and DataSets
+## DataFrames and Datasets
 
 Creating a dataframe is easy you can either load the data via `DefaultSource` or use the `JavaMongoRDD#toDF` method.
 
@@ -175,7 +175,7 @@ root
  |-- name: string (nullable = true)
 ```
 
-*Note:* Use the `toDS` method to convert a `JavaMongoRDD` into a `DataSet`.
+*Note:* Use the `toDS` method to convert a `JavaMongoRDD` into a `Dataset`.
 
 ### SQL
 
@@ -199,7 +199,7 @@ In the following example we save the centenarians into the "hundredClub" collect
 MongoSpark.write(centenarians).option("collection", "hundredClub").save();
 
 // Load the data from the "hundredClub" collection
-MongoSpark.load(MongoSpark.read(sqlContext).option("collection", "hundredClub"), Character.class).show();
+MongoSpark.builder().sqlContext(sqlContext).option("collection", "hundredClub").build().toDF(Character.class).show();
 ```
 
 Outputs:

--- a/doc/4-pyspark.md
+++ b/doc/4-pyspark.md
@@ -18,7 +18,7 @@ You can run the interactive pyspark shell like so:
 
 The python API works via DataFrames and uses underlying Scala DataFrame.
 
-## DataFrames and DataSets
+## DataFrames and Datasets
 
 Creating a dataframe is easy you can either load the data via `DefaultSource` ("com.mongodb.spark.sql.DefaultSource").
 

--- a/doc/5-sparkR.md
+++ b/doc/5-sparkR.md
@@ -18,7 +18,7 @@ You can run the interactive sparkR shell like so:
 
 The Spark R API works via DataFrames and uses underlying Scala DataFrame.
 
-## DataFrames and DataSets
+## DataFrames and Datasets
 
 Creating a dataframe is easy you can either load the data via `DefaultSource` ("com.mongodb.spark.sql.DefaultSource").
 

--- a/doc/7-Changelog.md
+++ b/doc/7-Changelog.md
@@ -1,6 +1,13 @@
 # Mongo Spark Connector Changelog
 
 ## 0.3-SNAPSHOT
+  * Added a MongoSpark builder and helper class for easy configuration of the Mongo Spark Connector.
+  * Simplified the java MongoSpark helper as the default MongoSpark helper can be used from Java.
+  * Added abstract class `Logging` so that implementations can be extended easily in Java.
+  * [[SPARK-55](https://jira.mongodb.org/browse/SPARK-55)] Made Paritioners public.
+  * [[SPARK-52](https://jira.mongodb.org/browse/SPARK-52)] MongoConnector is accessible from the new MongoSpark class or directly. 
+         Added Java specific methods for withMongoClient, withMongoDatabase and withMongoCollection.
+  * [[SPARK-50](https://jira.mongodb.org/browse/SPARK-50)] Made MongoPartition public added tests for custom partitioners.
   * [[SPARK-45](https://jira.mongodb.org/browse/SPARK-45)] Ensure that the SQLContext is reused correctly.
 
 ## 0.2

--- a/examples/src/test/java/tour/JavaIntroduction.java
+++ b/examples/src/test/java/tour/JavaIntroduction.java
@@ -132,12 +132,12 @@ public final class JavaIntroduction {
         df.show();
 
         // Via JavaMongoRDD
-        DataFrame rddDf = MongoSpark.load(sqlContext).toDF();
+        DataFrame rddDf = MongoSpark.load(jsc).toDF();
         rddDf.printSchema();
         df.show();
 
         // Declare the Schema via a Java Bean
-        DataFrame explicitDF = MongoSpark.load(sqlContext).toDF(Character.class);
+        DataFrame explicitDF = MongoSpark.load(jsc).toDF(Character.class);
         explicitDF.printSchema();
 
         // SQL
@@ -147,7 +147,7 @@ public final class JavaIntroduction {
         // Saving DataFrame
         MongoSpark.write(centenarians).option("collection", "hundredClub").save();
 
-        MongoSpark.load(MongoSpark.read(sqlContext).option("collection", "hundredClub"), Character.class).show();
+        MongoSpark.builder().sqlContext(sqlContext).option("collection", "hundredClub").build().toDF(Character.class).show();
     }
 
     private static JavaSparkContext createJavaSparkContext(final String[] args) {

--- a/src/main/scala/com/mongodb/spark/Logging.scala
+++ b/src/main/scala/com/mongodb/spark/Logging.scala
@@ -16,74 +16,9 @@
 
 package com.mongodb.spark
 
-import org.slf4j.{Logger, LoggerFactory}
-
 /**
- * Utility trait for classes that want to log data. Creates a SLF4J logger for the class and allows
- * logging messages at different levels using methods that only evaluate parameters lazily if the
- * log level is enabled.
+ * Utility abstract class implementation of Logging.
+ *
+ * Allows Java consumers to use the underlying Logging trait
  */
-private[spark] trait Logging {
-
-  // Make the log field transient so that objects with Logging can
-  // be serialized and used on another machine
-  @transient private var log_ : Logger = null // scalastyle:ignore
-
-  // Method to get the logger name for this object
-  protected def logName = {
-    // Ignore trailing $'s in the class names for Scala objects
-    this.getClass.getName.stripSuffix("$")
-  }
-
-  // Method to get or create the logger for this object
-  protected def log: Logger = {
-    if (log_ == null) { // scalastyle:ignore
-      log_ = LoggerFactory.getLogger(logName)
-    }
-    log_
-  }
-
-  // Log methods that take only a String
-  protected def logInfo(msg: => String) {
-    if (log.isInfoEnabled) log.info(msg)
-  }
-
-  protected def logDebug(msg: => String) {
-    if (log.isDebugEnabled) log.debug(msg)
-  }
-
-  protected def logTrace(msg: => String) {
-    if (log.isTraceEnabled) log.trace(msg)
-  }
-
-  protected def logWarning(msg: => String) {
-    if (log.isWarnEnabled) log.warn(msg)
-  }
-
-  protected def logError(msg: => String) {
-    if (log.isErrorEnabled) log.error(msg)
-  }
-
-  // Log methods that take Throwables (Exceptions/Errors) too
-  protected def logInfo(msg: => String, throwable: Throwable) {
-    if (log.isInfoEnabled) log.info(msg, throwable)
-  }
-
-  protected def logDebug(msg: => String, throwable: Throwable) {
-    if (log.isDebugEnabled) log.debug(msg, throwable)
-  }
-
-  protected def logTrace(msg: => String, throwable: Throwable) {
-    if (log.isTraceEnabled) log.trace(msg, throwable)
-  }
-
-  protected def logWarning(msg: => String, throwable: Throwable) {
-    if (log.isWarnEnabled) log.warn(msg, throwable)
-  }
-
-  protected def logError(msg: => String, throwable: Throwable) {
-    if (log.isErrorEnabled) log.error(msg, throwable)
-  }
-
-}
-
+private[spark] abstract class Logging extends LoggingTrait

--- a/src/main/scala/com/mongodb/spark/LoggingTrait.scala
+++ b/src/main/scala/com/mongodb/spark/LoggingTrait.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2016 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.spark
+
+import org.slf4j.{Logger, LoggerFactory}
+
+/**
+ * Utility trait for classes that want to log data. Creates a SLF4J logger for the class and allows
+ * logging messages at different levels using methods that only evaluate parameters lazily if the
+ * log level is enabled.
+ */
+private[spark] trait LoggingTrait {
+
+  // Make the log field transient so that objects with Logging can
+  // be serialized and used on another machine
+  @transient private var log_ : Logger = null // scalastyle:ignore
+
+  // Method to get the logger name for this object
+  protected def logName = {
+    // Ignore trailing $'s in the class names for Scala objects
+    this.getClass.getName.stripSuffix("$")
+  }
+
+  // Method to get or create the logger for this object
+  protected def log: Logger = {
+    if (log_ == null) { // scalastyle:ignore
+      log_ = LoggerFactory.getLogger(logName)
+    }
+    log_
+  }
+
+  // Log methods that take only a String
+  protected def logInfo(msg: => String) {
+    if (log.isInfoEnabled) log.info(msg)
+  }
+
+  protected def logDebug(msg: => String) {
+    if (log.isDebugEnabled) log.debug(msg)
+  }
+
+  protected def logTrace(msg: => String) {
+    if (log.isTraceEnabled) log.trace(msg)
+  }
+
+  protected def logWarning(msg: => String) {
+    if (log.isWarnEnabled) log.warn(msg)
+  }
+
+  protected def logError(msg: => String) {
+    if (log.isErrorEnabled) log.error(msg)
+  }
+
+  // Log methods that take Throwables (Exceptions/Errors) too
+  protected def logInfo(msg: => String, throwable: Throwable) {
+    if (log.isInfoEnabled) log.info(msg, throwable)
+  }
+
+  protected def logDebug(msg: => String, throwable: Throwable) {
+    if (log.isDebugEnabled) log.debug(msg, throwable)
+  }
+
+  protected def logTrace(msg: => String, throwable: Throwable) {
+    if (log.isTraceEnabled) log.trace(msg, throwable)
+  }
+
+  protected def logWarning(msg: => String, throwable: Throwable) {
+    if (log.isWarnEnabled) log.warn(msg, throwable)
+  }
+
+  protected def logError(msg: => String, throwable: Throwable) {
+    if (log.isErrorEnabled) log.error(msg, throwable)
+  }
+
+}
+

--- a/src/main/scala/com/mongodb/spark/MongoSpark.scala
+++ b/src/main/scala/com/mongodb/spark/MongoSpark.scala
@@ -1,0 +1,279 @@
+/*
+ * Copyright 2016 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.spark
+
+import scala.collection.JavaConverters._
+import scala.reflect.ClassTag
+import scala.reflect.runtime.universe._
+
+import org.apache.spark.SparkContext
+import org.apache.spark.api.java.JavaSparkContext
+import org.apache.spark.sql._
+
+import org.bson.Document
+import org.bson.conversions.Bson
+import com.mongodb.spark.DefaultHelper.DefaultsTo
+import com.mongodb.spark.config.ReadConfig
+import com.mongodb.spark.rdd.MongoRDD
+import com.mongodb.spark.rdd.api.java.JavaMongoRDD
+import com.mongodb.spark.rdd.partitioner.{DefaultMongoPartitioner, MongoPartitioner}
+
+/**
+ * The MongoSpark helper allows easy creation of RDDs, DataFrames or Datasets from MongoDB.
+ *
+ * @since 1.0
+ */
+object MongoSpark {
+
+  /**
+   * Create a builder for configuring the [[MongoSpark]]
+   *
+   * @return a MongoSession Builder
+   */
+  def builder(): Builder = new Builder
+
+  /**
+   * Builder for configuring and creating a [[MongoSpark]]
+   *
+   * It requires a `SparkContext` or `SQLContext`
+   */
+  class Builder {
+    private var sqlContext: Option[SQLContext] = None
+    private var connector: Option[MongoConnector] = None
+    private var partitioner: Option[MongoPartitioner] = None
+    private var readConfig: Option[ReadConfig] = None
+    private var pipeline: Seq[Bson] = Nil
+    private var options: collection.Map[String, String] = Map()
+
+    def build(): MongoSpark = {
+      require(sqlContext.isDefined, "The sqlContext must be set")
+      val sqlCtxt = sqlContext.get
+      val sc = sqlCtxt.sparkContext
+
+      new MongoSpark(
+        sqlCtxt,
+        partitioner.getOrElse(DefaultMongoPartitioner),
+        connector.getOrElse(MongoConnector(ReadConfig(ReadConfig.getOptionsFromConf(sc.getConf) ++ options, readConfig).asOptions)),
+        readConfig.getOrElse(ReadConfig(sc.getConf, options)),
+        pipeline
+      )
+    }
+
+    /**
+     * Sets the SQLContext from the sparkContext
+     *
+     * @param sparkContext for the RDD
+     */
+    def sparkContext(sparkContext: SparkContext): Builder = {
+      this.sqlContext = Option(SQLContext.getOrCreate(sparkContext))
+      this
+    }
+
+    /**
+     * Sets the SQLContext from the javaSparkContext
+     *
+     * @param javaSparkContext for the RDD
+     */
+    def javaSparkContext(javaSparkContext: JavaSparkContext): Builder = {
+      this.sqlContext = Option(SQLContext.getOrCreate(javaSparkContext.sc))
+      this
+    }
+
+    /**
+     * Sets the SQLContext
+     *
+     * @param sqlContext for the RDD
+     */
+    def sqlContext(sqlContext: SQLContext): Builder = {
+      this.sqlContext = Option(sqlContext)
+      this
+    }
+
+    /**
+     * Append a configuration option
+     *
+     * These options can be used to configure all aspects of how to connect to MongoDB
+     *
+     * @param key the configuration key
+     * @param value the configuration value
+     */
+    def option(key: String, value: String): Builder = {
+      this.options = this.options + (key -> value)
+      this
+    }
+
+    /**
+     * Set configuration options
+     *
+     * These options can configure all aspects of how to connect to MongoDB
+     *
+     * @param options the configuration options
+     */
+    def options(options: collection.Map[String, String]): Builder = {
+      this.options = options
+      this
+    }
+
+    /**
+     * Set configuration options
+     *
+     * These options can configure all aspects of how to connect to MongoDB
+     *
+     * @param options the configuration options
+     */
+    def options(options: java.util.Map[String, String]): Builder = {
+      this.options = options.asScala
+      this
+    }
+
+    /**
+     * Sets the [[com.mongodb.spark.MongoConnector]] to use
+     *
+     * @param connector the MongoConnector
+     */
+    def connector(connector: MongoConnector): Builder = {
+      this.connector = Option(connector)
+      this
+    }
+
+    /**
+     * Sets the [[com.mongodb.spark.rdd.partitioner.MongoPartitioner]] to use
+     *
+     * @param partitioner the partitioner
+     */
+    def partitioner(partitioner: MongoPartitioner): Builder = {
+      this.partitioner = Option(partitioner)
+      this
+    }
+
+    /**
+     * Sets the [[com.mongodb.spark.config.ReadConfig]] to use
+     *
+     * @param readConfig the readConfig
+     */
+    def readConfig(readConfig: ReadConfig): Builder = {
+      this.readConfig = Option(readConfig)
+      this
+    }
+
+    /**
+     * Sets the aggregation pipeline to use
+     *
+     * @param pipeline the aggregation pipeline
+     */
+    def pipeline(pipeline: Seq[Bson]): Builder = {
+      this.pipeline = pipeline
+      this
+    }
+  }
+
+}
+
+/**
+ * The MongoSpark class
+ *
+ * *Note:* Creation of the class should be via [[MongoSpark#builder()]].
+ *
+ * @since 1.0
+ */
+case class MongoSpark(sqlContext: SQLContext, partitioner: MongoPartitioner, connector: MongoConnector,
+                      readConfig: ReadConfig, pipeline: Seq[Bson]) {
+
+  private def rdd[D: ClassTag]()(implicit e: D DefaultsTo Document): MongoRDD[D] =
+    new MongoRDD[D](sqlContext, sqlContext.sparkContext.broadcast(connector), partitioner, readConfig, pipeline)
+
+  /**
+   * Creates a `RDD` for the collection
+   *
+   * @tparam D the datatype for the collection
+   * @return a MongoRDD[D]
+   */
+  def toRDD[D: ClassTag]()(implicit e: D DefaultsTo Document): MongoRDD[D] = rdd[D]
+
+  /**
+   * Creates a `JavaRDD` for the collection
+   *
+   * @return a JavaMongoRDD[Document]
+   */
+  def toJavaRDD(): JavaMongoRDD[Document] = rdd[Document].toJavaRDD()
+
+  /**
+   * Creates a `JavaRDD` for the collection
+   *
+   * @param clazz   the class of the data contained in the RDD
+   * @tparam D the type of the data in the RDD
+   * @return the javaRDD
+   */
+  def toJavaRDD[D](clazz: Class[D]): JavaMongoRDD[D] = {
+    implicit def ct: ClassTag[D] = ClassTag(clazz)
+    rdd[D].toJavaRDD()
+  }
+
+  /**
+   * Creates a `DataFrame` based on the schema derived from the optional type.
+   *
+   * '''Note:''' Prefer [[toDS[T<:Product]()*]] as computations will be more efficient.
+   *  The rdd must contain an `_id` for MongoDB versions < 3.2.
+   *
+   * @tparam D The optional type of the data from MongoDB, if not provided the schema will be inferred from the collection
+   * @return a DataFrame
+   */
+  def toDF[D <: Product: TypeTag](): DataFrame = rdd[Document].toDF[D]()
+
+  /**
+   * Creates a `DataFrame` based on the schema derived from the bean class.
+   *
+   * '''Note:''' Prefer [[toDS[D](beanClass:Class[D])*]] as computations will be more efficient.
+   *
+   * @param beanClass encapsulating the data from MongoDB
+   * @tparam D The bean class type to shape the data from MongoDB into
+   * @return a DataFrame
+   */
+  def toDF[D](beanClass: Class[D]): DataFrame = rdd[Document].toDF[D](beanClass)
+
+  /**
+   * Creates a `Dataset` from the collection strongly typed to the provided case class.
+   *
+   * @tparam D The type of the data from MongoDB
+   * @return
+   */
+  def toDS[D <: Product: TypeTag: NotNothing](): Dataset[D] = rdd[Document].toDS[D]()
+
+  /**
+   * Creates a `Dataset` from the RDD strongly typed to the provided java bean.
+   *
+   * @tparam D The type of the data from MongoDB
+   * @return
+   */
+  def toDS[D](beanClass: Class[D]): Dataset[D] = rdd[Document].toDS[D](beanClass)
+
+  /**
+   * Creates a DataFrameReader with the `MongoDB` underlying output data source.
+   *
+   * @return the DataFrameReader
+   */
+  def read(): DataFrameReader = sqlContext.read.options(readConfig.asOptions).format("com.mongodb.spark.sql")
+
+  /**
+   * Creates a DataFrameWriter with the `MongoDB` underlying output data source.
+   *
+   * @param dataFrame the DataFrame to convert into a DataFrameWriter
+   * @return the DataFrameWriter
+   */
+  def write(dataFrame: DataFrame): DataFrameWriter = dataFrame.write.format("com.mongodb.spark.sql")
+}
+

--- a/src/main/scala/com/mongodb/spark/SparkContextFunctions.scala
+++ b/src/main/scala/com/mongodb/spark/SparkContextFunctions.scala
@@ -21,9 +21,7 @@ import scala.reflect.ClassTag
 import org.apache.spark.{SparkConf, SparkContext}
 
 import org.bson.Document
-import org.bson.conversions.Bson
 import com.mongodb.spark.DefaultHelper.DefaultsTo
-import com.mongodb.spark.config.ReadConfig
 import com.mongodb.spark.rdd.MongoRDD
 
 /**
@@ -43,61 +41,6 @@ case class SparkContextFunctions(@transient sc: SparkContext) extends Serializab
    * @return a MongoRDD
    */
   def loadFromMongoDB[D: ClassTag]()(implicit e: D DefaultsTo Document): MongoRDD[D] =
-    MongoRDD[D](sc, MongoConnector(sc), ReadConfig(sc), Nil)
-
-  /**
-   * Creates a MongoRDD
-   *
-   * @param readConfig   the [[com.mongodb.spark.config.ReadConfig]]
-   * @tparam D the type of Document to return from MongoDB - defaults to Document
-   * @return a MongoRDD
-   */
-  def loadFromMongoDB[D: ClassTag](readConfig: ReadConfig)(implicit e: D DefaultsTo Document): MongoRDD[D] =
-    MongoRDD[D](sc, MongoConnector(ReadConfig(sc.getConf, readConfig.asOptions).asOptions), readConfig, Nil)
-
-  /**
-   * Creates a MongoRDD
-   *
-   * @param readConfig   the [[com.mongodb.spark.config.ReadConfig]]
-   * @param pipeline the aggregate pipeline
-   * @tparam D the type of Document to return from MongoDB - defaults to Document
-   * @return a MongoRDD
-   */
-  def loadFromMongoDB[D: ClassTag](readConfig: ReadConfig, pipeline: Seq[Bson])(implicit e: D DefaultsTo Document): MongoRDD[D] =
-    MongoRDD[D](sc, MongoConnector(readConfig.asOptions), readConfig, pipeline)
-
-  /**
-   * Creates a MongoRDD
-   *
-   * @param connector    the [[com.mongodb.spark.MongoConnector]]
-   * @tparam D the type of Document to return from MongoDB - defaults to Document
-   * @return a MongoRDD
-   */
-  def loadFromMongoDB[D: ClassTag](connector: MongoConnector)(implicit e: D DefaultsTo Document): MongoRDD[D] =
-    MongoRDD[D](sc, connector, ReadConfig(sc), Nil)
-
-  /**
-   * Creates a MongoRDD
-   *
-   * @param connector    the [[com.mongodb.spark.MongoConnector]]
-   * @param pipeline the aggregate pipeline
-   * @tparam D the type of Document to return from MongoDB - defaults to Document
-   * @return a MongoRDD
-   */
-  def loadFromMongoDB[D: ClassTag](connector: MongoConnector, pipeline: Seq[Bson])(implicit e: D DefaultsTo Document): MongoRDD[D] =
-    MongoRDD[D](sc, connector, ReadConfig(sc), pipeline)
-
-  /**
-   * Creates a MongoRDD
-   *
-   * @param connector    the [[com.mongodb.spark.MongoConnector]]
-   * @param readConfig   the [[com.mongodb.spark.config.ReadConfig]]
-   * @param pipeline the aggregate pipeline
-   * @tparam D the type of Document to return from MongoDB - defaults to Document
-   * @return a MongoRDD
-   */
-  def loadFromMongoDB[D: ClassTag](connector: MongoConnector, readConfig: ReadConfig,
-                                   pipeline: Seq[Bson])(implicit e: D DefaultsTo Document): MongoRDD[D] =
-    MongoRDD[D](sc, connector, readConfig, pipeline)
+    MongoSpark.builder().sparkContext(sc).build().toRDD[D]()
 
 }

--- a/src/main/scala/com/mongodb/spark/config/MongoCompanionConfig.scala
+++ b/src/main/scala/com/mongodb/spark/config/MongoCompanionConfig.scala
@@ -85,10 +85,8 @@ trait MongoCompanionConfig extends Serializable {
    * @param options overloaded parameters
    * @return the configuration
    */
-  def apply(sparkConf: SparkConf, options: collection.Map[String, String]): Self = {
-    val defaults = sparkConf.getAll.filter(_._1.startsWith(configPrefix)).toMap
-    apply(prefixLessOptions(defaults) ++ prefixLessOptions(options))
-  }
+  def apply(sparkConf: SparkConf, options: collection.Map[String, String]): Self =
+    apply(getOptionsFromConf(sparkConf) ++ prefixLessOptions(options))
 
   /**
    * Create a configuration from the values in the `Map`
@@ -169,8 +167,22 @@ trait MongoCompanionConfig extends Serializable {
    */
   def create(options: util.Map[String, String], default: Self): Self
 
-  protected def prefixLessOptions(options: collection.Map[String, String]): collection.Map[String, String] =
+  /**
+   * Strip the prefix from options
+   *
+   * @param options options that may contain the prefix
+   * @return prefixLess options
+   */
+  def prefixLessOptions(options: collection.Map[String, String]): collection.Map[String, String] =
     options.map(kv => (kv._1.toLowerCase.stripPrefix(configPrefix), kv._2))
+
+  /**
+   * Gets an options map from the `SparkConf`
+   * @param sparkConf the SparkConf
+   * @return the options
+   */
+  def getOptionsFromConf(sparkConf: SparkConf): collection.Map[String, String] =
+    prefixLessOptions(sparkConf.getAll.filter(_._1.startsWith(configPrefix)).toMap)
 
   protected def getInt(newValue: Option[String], existingValue: Option[Int] = None, defaultValue: Int): Int = {
     newValue match {

--- a/src/main/scala/com/mongodb/spark/connection/MongoClientCache.scala
+++ b/src/main/scala/com/mongodb/spark/connection/MongoClientCache.scala
@@ -20,14 +20,14 @@ package com.mongodb.spark.connection
 
 import java.util.concurrent.{Executors, ThreadFactory, TimeUnit}
 
-import com.mongodb.MongoClient
-import com.mongodb.spark.{Logging, MongoClientFactory}
-
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.duration.Duration
 import scala.util.{Failure, Success, Try}
+
+import com.mongodb.MongoClient
+import com.mongodb.spark.{Logging, MongoClientFactory}
 
 /**
  * A lockless cache for MongoClients.

--- a/src/main/scala/com/mongodb/spark/rdd/partitioner/DefaultMongoPartitioner.scala
+++ b/src/main/scala/com/mongodb/spark/rdd/partitioner/DefaultMongoPartitioner.scala
@@ -23,7 +23,16 @@ import com.mongodb.MongoCommandException
 import com.mongodb.spark.MongoConnector
 import com.mongodb.spark.config.ReadConfig
 
-private[rdd] case object DefaultMongoPartitioner extends MongoPartitioner {
+/**
+ * The default collection partitioner implementation
+ *
+ * Checks if the collection is sharded then:
+ *  - If sharded uses the [[MongoShardedPartitioner]] to partition the collection by shard chunks
+ *  - If non sharded uses the [[MongoSplitVectorPartitioner]] to partition the collection by using the `splitVector` command.
+ *
+ * @since 1.0
+ */
+case object DefaultMongoPartitioner extends MongoPartitioner {
 
   override def partitions(connector: MongoConnector, readConfig: ReadConfig): Array[MongoPartition] = {
     val collStatsCommand: Document = new Document("collStats", readConfig.collectionName)

--- a/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoPartition.scala
+++ b/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoPartition.scala
@@ -16,10 +16,55 @@
 
 package com.mongodb.spark.rdd.partitioner
 
+import scala.collection.JavaConverters._
 import org.apache.spark.Partition
+
 import org.bson.BsonDocument
 
 /**
- * An identifier for a partition in a MongoRDD.
+ * The MongoPartition companion object
+ *
+ * @since 1.0
  */
-private[rdd] case class MongoPartition(index: Int, queryBounds: BsonDocument, locations: Seq[String] = Nil) extends Partition
+object MongoPartition {
+
+  /**
+   * Create a MongoPartition with no preferred locations
+   *
+   * @param index The partition's index within its parent RDD
+   * @param queryBounds The query bounds for the data within this partition
+   * @return the MongoPartition
+   */
+  def apply(index: Int, queryBounds: BsonDocument): MongoPartition = new MongoPartition(index, queryBounds, Nil)
+
+  /**
+   * Create a MongoPartition with no preferred locations from the Java API
+   *
+   * @param index The partition's index within its parent RDD
+   * @param queryBounds The query bounds for the data within this partition
+   * @return the MongoPartition
+   */
+  def create(index: Int, queryBounds: BsonDocument): MongoPartition = apply(index, queryBounds)
+
+  /**
+   * Create a MongoPartition from the Java API
+   *
+   * @param index The partition's index within its parent RDD
+   * @param queryBounds The query bounds for the data within this partition
+   * @param locations The preferred locations (hostnames) for the data
+   * @return the MongoPartition
+   */
+  def create(index: Int, queryBounds: BsonDocument, locations: java.util.List[String]): MongoPartition =
+    new MongoPartition(index, queryBounds, locations.asScala)
+}
+
+/**
+ * An identifier for a partition in a MongoRDD.
+ *
+ * @param index The partition's index within its parent RDD
+ * @param queryBounds The query bounds for the data within this partition
+ * @param locations The preferred locations (hostnames) for the data
+ *
+ * @since 1.0
+ */
+case class MongoPartition(index: Int, queryBounds: BsonDocument, locations: Seq[String]) extends Partition

--- a/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoPartitioner.scala
+++ b/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoPartitioner.scala
@@ -16,8 +16,8 @@
 
 package com.mongodb.spark.rdd.partitioner
 
-import com.mongodb.spark.{Logging, MongoConnector}
 import com.mongodb.spark.config.ReadConfig
+import com.mongodb.spark.{Logging, MongoConnector}
 
 /**
  * The MongoPartitioner provides the partitions of a collection

--- a/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoShardedPartitioner.scala
+++ b/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoShardedPartitioner.scala
@@ -27,7 +27,14 @@ import com.mongodb.client.model.{Filters, Projections}
 import com.mongodb.spark.MongoConnector
 import com.mongodb.spark.config.ReadConfig
 
-private[partitioner] case object MongoShardedPartitioner extends MongoPartitioner {
+/**
+ * The Sharded Partitioner
+ *
+ * Partitions collections by shard and chunk.
+ *
+ * @since 1.0
+ */
+case object MongoShardedPartitioner extends MongoPartitioner {
 
   override def partitions(connector: MongoConnector, readConfig: ReadConfig): Array[MongoPartition] = {
     val ns: String = s"${readConfig.databaseName}.${readConfig.collectionName}"
@@ -67,7 +74,7 @@ private[partitioner] case object MongoShardedPartitioner extends MongoPartitione
     }).toArray
   }
 
-  private def mapShards(connector: MongoConnector): Map[String, Seq[String]] = {
+  private[partitioner] def mapShards(connector: MongoConnector): Map[String, Seq[String]] = {
     connector.withCollectionDo(
       ReadConfig("config", "shards"), { collection: MongoCollection[BsonDocument] =>
         Map(collection.find().projection(Projections.include("_id", "host")).into(new util.ArrayList[BsonDocument]).asScala
@@ -77,5 +84,5 @@ private[partitioner] case object MongoShardedPartitioner extends MongoPartitione
   }
 
   private[partitioner] def getHosts(hosts: String): Seq[String] = hosts.split(",").toSeq.map(getHost).distinct
-  private def getHost(hostAndPort: String): String = new ServerAddress(hostAndPort.split("/").reverse.head).getHost
+  private[partitioner] def getHost(hostAndPort: String): String = new ServerAddress(hostAndPort.split("/").reverse.head).getHost
 }

--- a/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoSinglePartitioner.scala
+++ b/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoSinglePartitioner.scala
@@ -20,7 +20,16 @@ import org.bson.BsonDocument
 import com.mongodb.spark.MongoConnector
 import com.mongodb.spark.config.ReadConfig
 
-private[rdd] case object MongoSinglePartitioner extends MongoPartitioner {
+/**
+ * The Single Partitioner.
+ *
+ * Creates a single partition for the whole collection.
+ *
+ * *Note:* Using this partitioner loses any parallelism and therefore is not generally recommended.
+ *
+ * @since 1.0
+ */
+case object MongoSinglePartitioner extends MongoPartitioner {
   override def partitions(connector: MongoConnector, readConfig: ReadConfig): Array[MongoPartition] =
     Array(MongoPartition(0, new BsonDocument()))
 }

--- a/src/main/scala/com/mongodb/spark/sql/MongoDataFrameReaderFunctions.scala
+++ b/src/main/scala/com/mongodb/spark/sql/MongoDataFrameReaderFunctions.scala
@@ -18,13 +18,13 @@ package com.mongodb.spark.sql
 
 import scala.reflect.runtime.universe._
 
-import com.mongodb.spark.Logging
+import com.mongodb.spark.LoggingTrait
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, DataFrameReader}
 
 import com.mongodb.spark.config.ReadConfig
 
-private[spark] case class MongoDataFrameReaderFunctions(@transient val dfr: DataFrameReader) extends Serializable with Logging {
+private[spark] case class MongoDataFrameReaderFunctions(@transient val dfr: DataFrameReader) extends Serializable with LoggingTrait {
 
   /**
    * Creates a [[DataFrame]] through schema inference via the `T` type, otherwise will sample the collection to

--- a/src/main/scala/com/mongodb/spark/sql/MongoDataFrameWriterFunctions.scala
+++ b/src/main/scala/com/mongodb/spark/sql/MongoDataFrameWriterFunctions.scala
@@ -16,12 +16,12 @@
 
 package com.mongodb.spark.sql
 
-import com.mongodb.spark.Logging
+import com.mongodb.spark.LoggingTrait
 import org.apache.spark.sql.DataFrameWriter
 
 import com.mongodb.spark.config.WriteConfig
 
-class MongoDataFrameWriterFunctions(@transient val dfw: DataFrameWriter) extends Serializable with Logging {
+class MongoDataFrameWriterFunctions(@transient val dfw: DataFrameWriter) extends Serializable with LoggingTrait {
 
   private val source: String = "com.mongodb.spark.sql.DefaultSource"
 

--- a/src/main/scala/com/mongodb/spark/sql/MongoRelation.scala
+++ b/src/main/scala/com/mongodb/spark/sql/MongoRelation.scala
@@ -22,16 +22,15 @@ import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{Row, SQLContext}
 
 import org.bson.BsonDocument
-import com.mongodb.spark.Logging
-import com.mongodb.spark.config.ReadConfig
+import com.mongodb.spark.LoggingTrait
 import com.mongodb.spark.rdd.MongoRDD
 import com.mongodb.spark.sql.MapFunctions.documentToRow
 import com.mongodb.spark.sql.MongoRelationHelper.createPipeline
 
-case class MongoRelation(mongoRDD: MongoRDD[BsonDocument], readConfig: ReadConfig, _schema: Option[StructType])(@transient val sqlContext: SQLContext)
+case class MongoRelation(mongoRDD: MongoRDD[BsonDocument], _schema: Option[StructType])(@transient val sqlContext: SQLContext)
     extends BaseRelation
     with PrunedFilteredScan
-    with Logging {
+    with LoggingTrait {
 
   override lazy val schema: StructType = _schema.getOrElse(MongoInferSchema(sqlContext.sparkContext))
 

--- a/src/main/scala/com/mongodb/spark/sql/SparkSQLContextFunctions.scala
+++ b/src/main/scala/com/mongodb/spark/sql/SparkSQLContextFunctions.scala
@@ -22,10 +22,8 @@ import org.apache.spark.sql.SQLContext
 import org.apache.spark.{SparkConf, SparkContext}
 
 import org.bson.Document
-import org.bson.conversions.Bson
 import com.mongodb.spark.DefaultHelper.DefaultsTo
-import com.mongodb.spark.MongoConnector
-import com.mongodb.spark.config.ReadConfig
+import com.mongodb.spark.MongoSpark
 import com.mongodb.spark.rdd.MongoRDD
 
 /**
@@ -40,16 +38,12 @@ case class SparkSQLContextFunctions(@transient sqlContext: SQLContext) extends S
   @transient private val sparkConf: SparkConf = sc.getConf
 
   /**
-   * Creates a MongoRDD
+   * Creates a MongoRDD using the current SQLContext
    *
-   * @param connector    the [[com.mongodb.spark.MongoConnector]]
-   * @param readConfig   the [[com.mongodb.spark.config.ReadConfig]]
-   * @param pipeline the aggregate pipeline
    * @tparam D the type of Document to return from MongoDB - defaults to Document
    * @return a MongoRDD
    */
-  def loadFromMongoDB[D: ClassTag](connector: MongoConnector = MongoConnector(sc), readConfig: ReadConfig = ReadConfig(sc),
-                                   pipeline: Seq[Bson] = Nil)(implicit e: D DefaultsTo Document): MongoRDD[D] =
-    MongoRDD[D](sqlContext, connector, readConfig, pipeline)
+  def loadFromMongoDB[D: ClassTag]()(implicit e: D DefaultsTo Document): MongoRDD[D] =
+    MongoSpark.builder().sqlContext(sqlContext).build().toRDD[D]()
 
 }

--- a/src/test/java/com/mongodb/spark/api/java/HalfwayPartitioner.java
+++ b/src/test/java/com/mongodb/spark/api/java/HalfwayPartitioner.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.spark.api.java;
+
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Projections;
+import com.mongodb.spark.MongoConnector;
+import com.mongodb.spark.config.ReadConfig;
+import com.mongodb.spark.rdd.partitioner.MongoPartition;
+import com.mongodb.spark.rdd.partitioner.MongoPartitioner;
+import org.apache.spark.api.java.function.Function;
+import org.bson.BsonDocument;
+import org.bson.BsonValue;
+
+public final class HalfwayPartitioner implements MongoPartitioner {
+    @Override
+    public MongoPartition[] partitions(final MongoConnector connector, final ReadConfig readConfig) {
+        BsonValue midId = connector.withCollectionDo(readConfig, BsonDocument.class, new Function<MongoCollection<BsonDocument>,
+                BsonValue>() {
+            @Override
+            public BsonValue call(final MongoCollection<BsonDocument> collection) throws Exception {
+                int midPoint = (int) (collection.count() / 2);
+                return collection.find().skip(midPoint).limit(1).projection(Projections.include("_id")).first().get("_id");
+            }
+        });
+        return new MongoPartition[]{ MongoPartition.create(0, new BsonDocument("_id", new BsonDocument("$lt", midId))),
+                                     MongoPartition.create(1, new BsonDocument("_id", new BsonDocument("$gte", midId)))};
+    }
+}

--- a/src/test/java/com/mongodb/spark/api/java/NoSparkConfTest.java
+++ b/src/test/java/com/mongodb/spark/api/java/NoSparkConfTest.java
@@ -51,7 +51,7 @@ public final class NoSparkConfTest extends RequiresMongoDB {
         List<Document> documents = asList(Document.parse("{test: 0}"), Document.parse("{test: 1}"), Document.parse("{test: 2}"));
 
         MongoSpark.save(jsc.parallelize(documents), writeConfig);
-        JavaMongoRDD<Document> mongoRDD = MongoSpark.load(jsc, readConfig);
+        JavaMongoRDD<Document> mongoRDD = MongoSpark.builder().javaSparkContext(jsc).readConfig(readConfig).build().toJavaRDD();
 
         assertEquals(mongoRDD.count(), 3);
 

--- a/src/test/java/com/mongodb/spark/api/java/sql/MongoDataFrameReaderTest.java
+++ b/src/test/java/com/mongodb/spark/api/java/sql/MongoDataFrameReaderTest.java
@@ -56,7 +56,7 @@ public final class MongoDataFrameReaderTest extends RequiresMongoDB {
         StructType expectedSchema = createStructType(asList(_idField, ageField, nameField));
 
         // When
-        DataFrame df = MongoSpark.read(SQLContext.getOrCreate(jsc.sc())).load();
+        DataFrame df = MongoSpark.load(jsc).toDF();
 
         // Then
         assertEquals(df.schema(), expectedSchema);
@@ -72,7 +72,7 @@ public final class MongoDataFrameReaderTest extends RequiresMongoDB {
         StructType expectedSchema = createStructType(asList(_idField, ageField, nameField));
 
         // When
-        DataFrame df = MongoSpark.load(MongoSpark.read(SQLContext.getOrCreate(jsc.sc())));
+        DataFrame df = MongoSpark.load(jsc).toDF();
 
         // Then
         assertEquals(df.schema(), expectedSchema);
@@ -131,7 +131,7 @@ public final class MongoDataFrameReaderTest extends RequiresMongoDB {
         StructType expectedSchema = createStructType(asList(ageField, nameField));
 
         // When
-        DataFrame df = MongoSpark.load(MongoSpark.read(SQLContext.getOrCreate(jsc.sc())), Character.class);
+        DataFrame df = MongoSpark.load(jsc).toDF(Character.class);
 
         // Then
         assertEquals(df.schema(), expectedSchema);

--- a/src/test/scala/com/mongodb/spark/AuthConnectionSpec.scala
+++ b/src/test/scala/com/mongodb/spark/AuthConnectionSpec.scala
@@ -31,7 +31,7 @@ class AuthConnectionSpec extends RequiresMongoDB {
     val sc = new SparkContext(sparkConf)
     val dbName = Option(new MongoClientURI(mongoClientURI).getDatabase).getOrElse(databaseName)
     val readConfig = ReadConfig(sc.getConf, Map("database" -> dbName))
-    val mongoRDD: MongoRDD[Document] = sc.loadFromMongoDB(readConfig = readConfig)
+    val mongoRDD: MongoRDD[Document] = MongoSpark.builder().sparkContext(sc).readConfig(readConfig).build().toRDD()
 
     Try(mongoRDD.count()) shouldBe a[Success[_]]
     sc.stop()

--- a/src/test/scala/com/mongodb/spark/HalfwayPartitioner.scala
+++ b/src/test/scala/com/mongodb/spark/HalfwayPartitioner.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.spark
+
+import org.bson.BsonDocument
+import com.mongodb.client.MongoCollection
+import com.mongodb.client.model.Projections
+import com.mongodb.spark.config.ReadConfig
+import com.mongodb.spark.rdd.partitioner.{MongoPartition, MongoPartitioner}
+
+object HalfwayPartitioner extends MongoPartitioner {
+  override def partitions(connector: MongoConnector, readConfig: ReadConfig): Array[MongoPartition] = {
+    val midId = connector.withCollectionDo(readConfig, { collection: MongoCollection[BsonDocument] =>
+      @transient val midPoint = collection.count() / 2
+      collection.find().skip(midPoint.toInt).limit(1).projection(Projections.include("_id")).first().get("_id")
+    })
+    Array(
+      MongoPartition(0, new BsonDocument("_id", new BsonDocument("$lt", midId))),
+      MongoPartition(1, new BsonDocument("_id", new BsonDocument("$gte", midId)))
+    )
+  }
+}

--- a/src/test/scala/com/mongodb/spark/MongoRDDSpec.scala
+++ b/src/test/scala/com/mongodb/spark/MongoRDDSpec.scala
@@ -16,7 +16,6 @@
 
 package com.mongodb.spark
 
-import org.scalatest.FlatSpec
 import org.apache.spark.SparkException
 import org.apache.spark.sql.catalyst.ScalaReflection
 import org.apache.spark.sql.types.DataTypes._
@@ -27,6 +26,8 @@ import org.bson.{BsonDocument, Document}
 import com.mongodb.client.model.{Aggregates, Filters}
 import com.mongodb.spark.rdd.MongoRDD
 import com.mongodb.spark.sql.types.BsonCompatibility
+
+import org.scalatest.FlatSpec
 
 class MongoRDDSpec extends FlatSpec with RequiresMongoDB {
   val counters =
@@ -113,6 +114,14 @@ class MongoRDDSpec extends FlatSpec with RequiresMongoDB {
     val dataset: Dataset[Counter] = sc.loadFromMongoDB().toDS[Counter]()
     import dataset.sqlContext.implicits._
     dataset.map(counter => counter.counter).collectAsList() should contain theSameElementsAs List(None, None)
+  }
+
+  it should "be easy to use a custom partitioner" in withSparkContext() { sc =>
+    sc.parallelize((1 to 100).map(i => Document.parse(s"{number: $i}"))).saveToMongoDB()
+
+    val mongoRDD: MongoRDD[Document] = MongoSpark.builder().sparkContext(sc).partitioner(HalfwayPartitioner).build().toRDD()
+    mongoRDD.getNumPartitions should equal(2)
+    mongoRDD.mapPartitions(iter => Array(iter.size).iterator).collect() should equal(Array(50, 50)) // scalastyle:ignore
   }
 
 }

--- a/src/test/scala/com/mongodb/spark/NoSparkConfSpec.scala
+++ b/src/test/scala/com/mongodb/spark/NoSparkConfSpec.scala
@@ -21,8 +21,7 @@ import org.apache.spark.{SparkConf, SparkContext}
 
 import org.bson.Document
 import com.mongodb.spark.config.{ReadConfig, WriteConfig}
-import com.mongodb.spark.sql._
-import com.mongodb.spark.sql.Character
+import com.mongodb.spark.sql.{Character, _}
 
 class NoSparkConfSpec extends RequiresMongoDB {
 
@@ -33,8 +32,9 @@ class NoSparkConfSpec extends RequiresMongoDB {
     val documents = sc.parallelize((1 to 10).map(i => Document.parse(s"{test: $i}")))
     documents.saveToMongoDB(writeConfig = writeConfig)
 
-    sc.loadFromMongoDB(readConfig = readConfig).count() should equal(10) //scalastyle:ignore
-    sc.loadFromMongoDB(readConfig = readConfig).map(_.getInteger("test")).collect().toList should equal((1 to 10).toList)
+    val rdd = MongoSpark.builder().sparkContext(sc).readConfig(readConfig).build().toRDD()
+    rdd.count() should equal(10) //scalastyle:ignore
+    rdd.map(_.getInteger("test")).collect().toList should equal((1 to 10).toList)
   }
 
   "DataFrame Readers and Writers" should "be able to accept just options" in {

--- a/src/test/scala/com/mongodb/spark/RequiresMongoDB.scala
+++ b/src/test/scala/com/mongodb/spark/RequiresMongoDB.scala
@@ -27,7 +27,7 @@ import com.mongodb.client.{MongoCollection, MongoDatabase}
 import com.mongodb.connection.ClusterType.{REPLICA_SET, SHARDED, STANDALONE}
 import com.mongodb.spark.config.ReadConfig
 
-trait RequiresMongoDB extends FlatSpec with Matchers with BeforeAndAfterAll with BeforeAndAfterEach with Logging {
+trait RequiresMongoDB extends FlatSpec with Matchers with BeforeAndAfterAll with BeforeAndAfterEach with LoggingTrait {
 
   private val mongoDBDefaults: MongoDBDefaults = MongoDBDefaults()
   private var _currentTestName: Option[String] = None

--- a/src/test/scala/com/mongodb/spark/sql/MongoDataFrameSpec.scala
+++ b/src/test/scala/com/mongodb/spark/sql/MongoDataFrameSpec.scala
@@ -27,6 +27,7 @@ import org.bson._
 import org.bson.types.ObjectId
 import com.mongodb.spark._
 import com.mongodb.spark.config.WriteConfig
+import com.mongodb.spark.rdd.MongoRDD
 import com.mongodb.spark.sql.types.BsonCompatibility
 
 import org.scalatest.FlatSpec
@@ -98,7 +99,7 @@ class MongoDataFrameSpec extends FlatSpec with RequiresMongoDB {
     val readConf = readConfig.withOptions(Map("collection" -> saveToCollectionName))
 
     SQLContext.getOrCreate(sc).read.mongo().write.mode(SaveMode.Overwrite).option("collection", saveToCollectionName).mongo()
-    sc.loadFromMongoDB(readConfig = readConfig).collect().toList should equal(arrayFieldWithNulls)
+    MongoSpark.builder().sparkContext(sc).readConfig(readConfig).build().toRDD().collect().toList should equal(arrayFieldWithNulls)
   }
 
   it should "handle document fields with null values" in withSparkContext() { sc =>
@@ -108,7 +109,7 @@ class MongoDataFrameSpec extends FlatSpec with RequiresMongoDB {
     val readConf = readConfig.withOptions(Map("collection" -> saveToCollectionName))
 
     SQLContext.getOrCreate(sc).read.mongo().write.mode(SaveMode.Overwrite).option("collection", saveToCollectionName).mongo()
-    sc.loadFromMongoDB(readConfig = readConfig).collect().toList should equal(documentFieldWithNulls)
+    MongoSpark.builder().sparkContext(sc).readConfig(readConfig).build().toRDD().collect().toList should equal(documentFieldWithNulls)
   }
 
   it should "be easily created with a provided case class" in withSparkContext() { sc =>

--- a/src/test/scala/com/mongodb/spark/sql/MongoInferSchemaSpec.scala
+++ b/src/test/scala/com/mongodb/spark/sql/MongoInferSchemaSpec.scala
@@ -78,7 +78,8 @@ class MongoInferSchemaSpec extends FlatSpec with MongoDataGenerator with Require
   it should "be able to infer the schema with custom sampleSize" in withSparkContext() { sc =>
     forAll(genDocumentDataType()) { (data: MongoDataType) =>
       sc.parallelize(data.getDocuments.toBson).saveToMongoDB()
-      data.schema should equal(MongoInferSchema(MongoRDD[BsonDocument](sc, readConfig.copy(sampleSize = 200)))) // scalastyle:ignore
+      val rdd = MongoSpark.builder().sparkContext(sc).readConfig(readConfig.copy(sampleSize = 200)).build().toRDD[BsonDocument]() //scalastyle:ignore
+      data.schema should equal(MongoInferSchema(rdd))
       database.drop()
     }
   }


### PR DESCRIPTION
* Added a MongoSpark builder and helper class for easy configuration of the connector.
* Simplified the java MongoSpark helper
* Added abstract class `Logging` so that implementations can be extended easily in Java
* Added Java specific methods for withMongoClient, withMongoDatabase and withMongoCollection
* Simplified MongoRDD by removing the confusing number of method overloads in MongoRDD
* Made MongoPartition public
* Added test cases for custom MongoPartitioners

SPARK-50, SPARK-52, SPARK-55