### PR TITLE
Partitioner changes

### DIFF
--- a/doc/2-configuring.md
+++ b/doc/2-configuring.md
@@ -28,8 +28,8 @@ spark.mongodb.input.readPreference.name    | The name of the `ReadPreference` to
 spark.mongodb.input.readPreference.tagSets | The `ReadPreference` TagSets to use                               |
 spark.mongodb.input.readConcern.level      | The `ReadConcern` level to use                                    |
 spark.mongodb.input.sampleSize             | The sample size to use when inferring the schema                  | 1000
-spark.mongodb.input.splitKey               | The partition key to split the data                               | `_id`
-spark.mongodb.input.maxChunkSize           | The maximum chunk size for partitioning an unsharded collection   | 64 MB
+spark.mongodb.input.partitionKey           | The partition key to partition the data for sharded collections   | `_id`
+spark.mongodb.input.partitionSizeMB        | The partition size for partitioning unsharded collections         | 64 MB
 
 -----
 **Note**: When passing input configurations via an options Map then the prefix `spark.mongodb.input.` is not needed.

--- a/doc/6-FAQ.md
+++ b/doc/6-FAQ.md
@@ -56,6 +56,19 @@ ssc.awaitTermination()
 
 Note: The Mongo Spark Connector only supports streams a sink.
 
+## What permissions do the partitioners require?
+
+Partitioner                         | Permissions required
+------------------------------------|-----------------------------------------------------------------------------------------
+`MongoPaginationPartitioner`        | Read collection
+`MongoSamplePartitioner`            | Read collection
+`MongoShardedPartitioner`           | Read `config` database. Reads from the `chunks` and `shards` collections.
+`MongoSinglePartitioner`            | None
+`MongoSplitVectorPartitioner`       | Runs the `SplitVector` command. Requires `clusterManager` role or a custom permission.
+
+The `DefaultMongoPartitioner` is a special case as for sharded collections it uses the `MongoShardedPartitioner` otherwise for MongoDB 3.2+ 
+it will use the `MongoSamplePartitioner` but will fallback to the `MongoPaginationPartitioner` for older versions.
+
 -----
 
 [Next - Changelog](7-Changelog.md)

--- a/doc/7-Changelog.md
+++ b/doc/7-Changelog.md
@@ -1,6 +1,10 @@
 # Mongo Spark Connector Changelog
 
-## 0.3-SNAPSHOT
+## 0.4
+  * [[SPARK-54](https://jira.mongodb.org/browse/SPARK-54)] Added a sample and pagination based partitioners. SplitVector no longer a default partitioner.
+  * [[SPARK-53](https://jira.mongodb.org/browse/SPARK-53)] Partition failures now explicitly thrown.
+
+## 0.3
   * [[SPARK-58](https://jira.mongodb.org/browse/SPARK-58)] Added the ability to explicitly pass schema when creating a DataFrame.
   * [[SPARK-59](https://jira.mongodb.org/browse/SPARK-59)] Fixed being able to directly connect to a single MongoD in a replicaSet.
   * [[SPARK-56](https://jira.mongodb.org/browse/SPARK-56)] Moved MongoSpark into the Scala API as the main gateway for configuring the connector

--- a/src/main/scala/com/mongodb/spark/MongoConnector.scala
+++ b/src/main/scala/com/mongodb/spark/MongoConnector.scala
@@ -17,22 +17,24 @@
 package com.mongodb.spark
 
 import java.io.{Closeable, Serializable}
+import java.util
 import java.util.concurrent.TimeUnit
 
 import scala.collection.JavaConverters._
-
-import com.mongodb.MongoClient
-import com.mongodb.client.{MongoCollection, MongoDatabase}
-import com.mongodb.spark.config.{MongoCollectionConfig, ReadConfig, WriteConfig}
-import com.mongodb.spark.connection.{DefaultMongoClientFactory, MongoClientCache}
-import org.apache.spark.{SparkConf, SparkContext}
-import org.apache.spark.api.java.function.Function
-
-import org.bson.codecs.configuration.CodecRegistry
 import scala.concurrent.duration.Duration
 import scala.reflect.ClassTag
 
 import org.apache.spark.api.java.JavaSparkContext
+import org.apache.spark.api.java.function.Function
+import org.apache.spark.{SparkConf, SparkContext}
+
+import org.bson.codecs.configuration.CodecRegistry
+import org.bson.{BsonDocument, Document}
+import com.mongodb.MongoClient
+import com.mongodb.client.{MongoCollection, MongoDatabase}
+import com.mongodb.connection.ServerVersion
+import com.mongodb.spark.config.{MongoCollectionConfig, ReadConfig, WriteConfig}
+import com.mongodb.spark.connection.{DefaultMongoClientFactory, MongoClientCache}
 
 /**
  * The MongoConnector companion object
@@ -218,6 +220,12 @@ case class MongoConnector(mongoClientFactory: MongoClientFactory)
   def withCollectionDo[D, T](config: MongoCollectionConfig, clazz: Class[D], code: Function[MongoCollection[D], T]): T = {
     implicit def ct: ClassTag[D] = ClassTag(clazz)
     withCollectionDo[D, T](config, { collection => code.call(collection) })
+  }
+
+  private[spark] def hasSampleAggregateOperator(readConfig: ReadConfig): Boolean = {
+    val buildInfo: BsonDocument = withDatabaseDo(readConfig, { db => db.runCommand(new Document("buildInfo", 1), classOf[BsonDocument]) })
+    val versionArray: util.List[Integer] = buildInfo.getArray("versionArray").asScala.take(3).map(_.asInt32().getValue.asInstanceOf[Integer]).asJava
+    new ServerVersion(versionArray).compareTo(new ServerVersion(3, 2)) >= 0
   }
 
   private[spark] def acquireClient(): MongoClient = MongoConnector.mongoClientCache.acquire(mongoClientFactory)

--- a/src/main/scala/com/mongodb/spark/config/MongoInputConfig.scala
+++ b/src/main/scala/com/mongodb/spark/config/MongoInputConfig.scala
@@ -38,8 +38,9 @@ package com.mongodb.spark.config
  *  - [[readPreferenceTagSetsProperty readPreference.tagSets]], the `ReadPreference` TagSets to use.
  *  - [[readConcernLevelProperty readConcern.level]], the `ReadConcern` level to use.
  *  - [[sampleSizeProperty sampleSize]], the sample size to use when inferring the schema.
- *  - [[splitKeyProperty splitKey]], the partition key to split the data.
- *  - [[maxChunkSizeProperty maxChunkSize]], the maximum chunk size when partitioning data from an unsharded collection.
+ *  - [[partitionKeyProperty partitionKey]], the partition key to partition the data. For sharded collections this would be the shard key,
+ *    otherwise this should be left as the default `_id`.
+ *  - [[partitionSizeMBProperty partitionSizeMB]], he size (in MB) for each partition. Used when partitioning unsharded collections.
  *  - [[localThresholdProperty localThreshold]], the number of milliseconds used when choosing among multiple MongoDB servers to send a request.
  *
  */
@@ -88,20 +89,21 @@ trait MongoInputConfig extends MongoCompanionConfig {
   val sampleSizeProperty = "sampleSize".toLowerCase
 
   /**
-   * The split key property
+   * The partition key property
    *
-   * Represents the key to be used when partitioning the data in the collection.
+   * Represents the key to be used when partitioning the data in the collection. For sharded collections this would be the "shard key",
+   * otherwise this should be left as the default `_id`.
    * Default: `_id`
    */
-  val splitKeyProperty = "splitKey".toLowerCase
+  val partitionKeyProperty = "partitionKey".toLowerCase
 
   /**
-   * The max chunk size property
+   * The partition size property
    *
-   * Represents the max size (in MB) for each partition. Only used when partitioning non-sharded collections.
+   * Represents the size (in MB) for each partition. Used when partitioning unsharded collections.
    * Default: `64`
    */
-  val maxChunkSizeProperty = "maxChunkSize".toLowerCase
+  val partitionSizeMBProperty = "partitionSizeMB".toLowerCase
 
   /**
    * The localThreshold property

--- a/src/main/scala/com/mongodb/spark/rdd/MongoRDD.scala
+++ b/src/main/scala/com/mongodb/spark/rdd/MongoRDD.scala
@@ -16,8 +16,6 @@
 
 package com.mongodb.spark.rdd
 
-import java.util
-
 import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe._
@@ -33,7 +31,6 @@ import org.bson.conversions.Bson
 import org.bson.{BsonDocument, Document}
 import com.mongodb.MongoClient
 import com.mongodb.client.MongoCursor
-import com.mongodb.connection.ServerVersion
 import com.mongodb.spark.config.ReadConfig
 import com.mongodb.spark.rdd.api.java.JavaMongoRDD
 import com.mongodb.spark.rdd.partitioner.{MongoPartition, MongoPartitioner}
@@ -181,14 +178,7 @@ class MongoRDD[D: ClassTag](
     )
   }
 
-  private[spark] lazy val hasSampleAggregateOperator: Boolean = {
-    val buildInfo: BsonDocument = connector.value.withDatabaseDo(
-      readConfig.copy(databaseName = "test"),
-      { db => db.runCommand(new Document("buildInfo", 1), classOf[BsonDocument]) }
-    )
-    val versionArray: util.List[Integer] = buildInfo.getArray("versionArray").asScala.take(3).map(_.asInt32().getValue.asInstanceOf[Integer]).asJava
-    new ServerVersion(versionArray).compareTo(new ServerVersion(3, 2)) >= 0
-  }
+  private[spark] lazy val hasSampleAggregateOperator: Boolean = connector.value.hasSampleAggregateOperator(readConfig)
 
   private[spark] def appendPipeline[B <: Bson](extraPipeline: Seq[B]): MongoRDD[D] = withPipeline(pipeline ++ extraPipeline)
 }

--- a/src/main/scala/com/mongodb/spark/rdd/MongoRDD.scala
+++ b/src/main/scala/com/mongodb/spark/rdd/MongoRDD.scala
@@ -24,7 +24,6 @@ import scala.util.Try
 import org.apache.spark._
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, Dataset, SQLContext}
 
 import org.bson.conversions.Bson

--- a/src/main/scala/com/mongodb/spark/rdd/MongoRDD.scala
+++ b/src/main/scala/com/mongodb/spark/rdd/MongoRDD.scala
@@ -24,6 +24,7 @@ import scala.util.Try
 import org.apache.spark._
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, Dataset, SQLContext}
 
 import org.bson.conversions.Bson

--- a/src/main/scala/com/mongodb/spark/rdd/partitioner/BsonValueOrdering.scala
+++ b/src/main/scala/com/mongodb/spark/rdd/partitioner/BsonValueOrdering.scala
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2016 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.spark.rdd.partitioner
+
+import scala.annotation.tailrec
+import scala.collection.JavaConverters._
+
+import org.bson._
+
+trait BsonValueOrdering extends Ordering[BsonValue] {
+
+  // scalastyle:off cyclomatic.complexity
+  private val bsonTypeComparisonMap: Map[BsonType, Int] = Map(
+    BsonType.MIN_KEY -> 1,
+    BsonType.NULL -> 2,
+    BsonType.INT32 -> 3,
+    BsonType.INT64 -> 3,
+    BsonType.DOUBLE -> 3,
+    BsonType.SYMBOL -> 4,
+    BsonType.STRING -> 4,
+    BsonType.DOCUMENT -> 5,
+    BsonType.ARRAY -> 6,
+    BsonType.BINARY -> 7,
+    BsonType.OBJECT_ID -> 8,
+    BsonType.BOOLEAN -> 9,
+    BsonType.DATE_TIME -> 10,
+    BsonType.TIMESTAMP -> 11,
+    BsonType.REGULAR_EXPRESSION -> 12,
+    BsonType.MAX_KEY -> 13
+  )
+
+  /**
+   *
+   * Returns an integer whose sign communicates how x compares to y.
+   *
+   * The result sign has the following meaning:
+   *
+   * - negative if x < y
+   * - positive if x > y
+   * - zero otherwise (if x == y)
+   *
+   * When comparing values of different BSON types, MongoDB uses the following comparison order, from lowest to highest:
+   *
+   * 1. MinKey (internal type)
+   * 2. Null
+   * 3. Numbers (ints, longs, doubles)
+   * 4. Symbol, String
+   * 5. Object
+   * 6. Array
+   * 7. BinData
+   * 8. ObjectId
+   * 9. Boolean
+   * 10. Date
+   * 11. Timestamp
+   * 12. Regular Expression
+   * 13. MaxKey (internal type)
+   */
+  override def compare(x: BsonValue, y: BsonValue): Int = {
+    (x.getBsonType, y.getBsonType) match {
+      case (BsonType.MIN_KEY, BsonType.MIN_KEY)     => 0
+      case (BsonType.NULL, BsonType.NULL)           => 0
+      case (isBsonNumber(), isBsonNumber())         => x.asNumber.doubleValue.compareTo(y.asNumber.doubleValue)
+      case (BsonType.STRING, BsonType.STRING)       => x.asString.getValue.compareTo(y.asString.getValue)
+      case (BsonType.SYMBOL, BsonType.STRING)       => x.asSymbol.getSymbol.compareTo(y.asString.getValue)
+      case (BsonType.STRING, BsonType.SYMBOL)       => x.asString.getValue.compareTo(y.asSymbol.getSymbol)
+      case (BsonType.SYMBOL, BsonType.SYMBOL)       => x.asSymbol.getSymbol.compareTo(y.asSymbol.getSymbol)
+      case (BsonType.DOCUMENT, BsonType.DOCUMENT)   => compareDocuments(x.asDocument, y.asDocument)
+      case (BsonType.ARRAY, BsonType.ARRAY)         => compareArrays(x.asArray, y.asArray)
+      case (BsonType.BINARY, BsonType.BINARY)       => compareBinary(x.asBinary, y.asBinary)
+      case (BsonType.OBJECT_ID, BsonType.OBJECT_ID) => x.asObjectId.getValue.compareTo(y.asObjectId.getValue)
+      case (BsonType.BOOLEAN, BsonType.BOOLEAN)     => x.asBoolean.getValue.compareTo(y.asBoolean().getValue)
+      case (BsonType.DATE_TIME, BsonType.DATE_TIME) => x.asDateTime.getValue.compareTo(y.asDateTime().getValue)
+      case (BsonType.TIMESTAMP, BsonType.TIMESTAMP) => compareTimestamps(x.asTimestamp, y.asTimestamp)
+      case (BsonType.REGULAR_EXPRESSION, BsonType.REGULAR_EXPRESSION) =>
+        compareRegularExpressions(x.asRegularExpression, y.asRegularExpression)
+      case (xType, yType) =>
+        val xSortScore = bsonTypeComparisonMap.getOrElse(x.getBsonType, 14) // scalastyle:ignore
+        val ySortScore = bsonTypeComparisonMap.getOrElse(y.getBsonType, 14) // scalastyle:ignore
+        xSortScore.compareTo(ySortScore)
+    }
+  }
+
+  private def compareDocuments(x: BsonDocument, y: BsonDocument): Int = {
+    val xKeyValues: Seq[(String, BsonValue)] = x.entrySet().asScala.map(x => (x.getKey, x.getValue)).toSeq
+    val yKeyValues: Seq[(String, BsonValue)] = y.entrySet().asScala.map(y => (y.getKey, y.getValue)).toSeq
+    compareKeyValues(xKeyValues zip yKeyValues) match {
+      case 0 => xKeyValues.length.compareTo(yKeyValues.length)
+      case v => v
+    }
+  }
+
+  private def compareArrays(x: BsonArray, y: BsonArray): Int = {
+    compareBsonValues(x.getValues.asScala zip y.getValues.asScala) match {
+      case 0 => x.getValues.size.compareTo(y.getValues.size)
+      case v => v
+    }
+  }
+
+  private def compareRegularExpressions(x: BsonRegularExpression, y: BsonRegularExpression): Int = {
+    x.getPattern.compareTo(y.getPattern) match {
+      case 0 => x.getOptions.compareTo(y.getOptions)
+      case v => v
+    }
+  }
+
+  private def compareBinary(x: BsonBinary, y: BsonBinary): Int = {
+    x.getData.length.compareTo(y.getData.length) match {
+      case 0 =>
+        x.getType.compareTo(y.getType) match {
+          case 0 => compareBytes(x.getData zip y.getData)
+          case v => v
+        }
+      case v => v
+    }
+  }
+
+  private def compareTimestamps(x: BsonTimestamp, y: BsonTimestamp): Int = {
+    x.getTime.compareTo(y.getTime) match {
+      case 0 => x.getInc.compareTo(y.getInc)
+      case v => v
+    }
+  }
+
+  @tailrec
+  private def compareKeyValues(kvs: Seq[((String, BsonValue), (String, BsonValue))]): Int = {
+    kvs.headOption match {
+      case Some(kv) => compareKeyValues(kv._1, kv._2) match {
+        case 0 => compareKeyValues(kvs.tail)
+        case v => v
+      }
+      case None => 0
+    }
+  }
+
+  private def compareKeyValues(x: (String, BsonValue), y: (String, BsonValue)): Int = {
+    x._1.compareTo(y._1) match {
+      case 0 => compare(x._2, y._2)
+      case v => v
+    }
+  }
+
+  @tailrec
+  private def compareBsonValues(values: Seq[(BsonValue, BsonValue)]): Int = {
+    values.headOption match {
+      case Some(value) => compare(value._1, value._2) match {
+        case 0 => compareBsonValues(values.tail)
+        case v => v
+      }
+      case None => 0
+    }
+  }
+
+  @tailrec
+  private def compareBytes(values: Seq[(Byte, Byte)]): Int = {
+    values.headOption match {
+      case Some(value) => value._1.compareTo(value._2) match {
+        case 0 => compareBytes(values.tail)
+        case v => v
+      }
+      case None => 0
+    }
+  }
+
+  private object isBsonNumber {
+    val bsonNumberTypes = Set(BsonType.INT32, BsonType.INT64, BsonType.DOUBLE)
+
+    def unapply(x: BsonType): Boolean = bsonNumberTypes.contains(x)
+  }
+
+  private object isString {
+    val bsonNumberTypes = Set(BsonType.SYMBOL, BsonType.STRING)
+
+    def unapply(x: BsonType): Boolean = bsonNumberTypes.contains(x)
+  }
+
+}
+
+// scalastyle:on cyclomatic.complexity

--- a/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoPaginationPartitioner.scala
+++ b/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoPaginationPartitioner.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2016 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.spark.rdd.partitioner
+import scala.util.{Failure, Success, Try}
+
+import org.bson.{BsonDocument, BsonValue}
+import com.mongodb.MongoCommandException
+import com.mongodb.client.MongoCollection
+import com.mongodb.client.model.Projections
+import com.mongodb.spark.MongoConnector
+import com.mongodb.spark.config.ReadConfig
+
+/**
+ * The Pagination Partitioner.
+ *
+ * Uses the `collStats` command and the average document size to estimate the partition boundaries.
+ *
+ * *Note:* This can be a expensive opertation as it creates 1 cursor for every estimated `partitionSizeMB`s worth of documents.
+ *
+ * @since 1.0
+ */
+case object MongoPaginationPartitioner extends MongoPartitioner {
+
+  /**
+   * Calculate the Partitions
+   *
+   * @param connector  the MongoConnector
+   * @param readConfig the [[com.mongodb.spark.config.ReadConfig]]
+   * @return the partitions
+   */
+  override def partitions(connector: MongoConnector, readConfig: ReadConfig): Array[MongoPartition] = {
+    require(readConfig.partitionKey == "_id", "The MongoPaginationPartitioner can only partition on `_id`")
+
+    Try(PartitionerHelper.collStats(connector, readConfig)) match {
+      case Success(results) =>
+        val partitionKey = "_id"
+        val partitionSizeInBytes = readConfig.partitionSizeMB * 1024 * 1024
+        val count = results.getNumber("count").longValue()
+        val avgObjSizeInBytes = results.getNumber("avgObjSize").longValue()
+        val size = results.getNumber("size").longValue()
+        val numberOfPartitions = math.ceil(size / partitionSizeInBytes.toFloat).toInt
+        val estNumDocumentsPerPartition: Int = math.ceil(partitionSizeInBytes.toFloat / avgObjSizeInBytes).toInt
+
+        val rightHandBoundaries = estNumDocumentsPerPartition >= count match {
+          case true => Seq.empty[BsonValue]
+          case false =>
+            val skipValues = (0 to numberOfPartitions.toInt).map(i => i * estNumDocumentsPerPartition)
+            skipValues.map(i => connector.withCollectionDo(readConfig, { coll: MongoCollection[BsonDocument] =>
+              i >= count match {
+                case true => None
+                case false =>
+                  Option(coll.find().skip(i).limit(-1).projection(Projections.include(partitionKey)).first()).map(_.get(partitionKey))
+              }
+            })).collect({ case Some(boundary) => boundary })
+        }
+        PartitionerHelper.createPartitions(partitionKey, rightHandBoundaries, PartitionerHelper.locations(connector))
+      case Failure(ex: MongoCommandException) if ex.getErrorMessage.endsWith("not found.") =>
+        logInfo(s"Could not find collection (${readConfig.collectionName}), using a single partition")
+        MongoSinglePartitioner.partitions(connector, readConfig)
+      case Failure(e) =>
+        logWarning(s"Could not get collection statistics. Server errmsg: ${e.getMessage}")
+        throw e
+    }
+  }
+
+}
+

--- a/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoSamplePartitioner.scala
+++ b/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoSamplePartitioner.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2016 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.spark.rdd.partitioner
+
+import java.util
+
+import scala.collection.JavaConverters._
+import scala.util.{Failure, Success, Try}
+
+import org.bson.{BsonDocument, BsonValue}
+import com.mongodb.MongoCommandException
+import com.mongodb.client.MongoCollection
+import com.mongodb.client.model.{Aggregates, Projections, Sorts}
+import com.mongodb.spark.MongoConnector
+import com.mongodb.spark.config.ReadConfig
+
+/**
+ * The Sample Partitioner.
+ *
+ * Uses the average document size and random sampling of the collection to determine suitable partitions for the collection.
+ *
+ * *Note:* Requires MongoDB 3.2+
+ *
+ * @since 1.0
+ */
+case object MongoSamplePartitioner extends MongoPartitioner {
+
+  private val samplesPerPartition = 10
+
+  /**
+   * Calculate the Partitions
+   *
+   * @param connector  the MongoConnector
+   * @param readConfig the [[com.mongodb.spark.config.ReadConfig]]
+   * @return the partitions
+   */
+  override def partitions(connector: MongoConnector, readConfig: ReadConfig): Array[MongoPartition] = {
+    Try(PartitionerHelper.collStats(connector, readConfig)) match {
+      case Success(results) =>
+        val partitionKey = "_id"
+        val partitionSizeInBytes = readConfig.partitionSizeMB * 1024 * 1024
+        val count = results.getNumber("count").longValue()
+        val avgObjSizeInBytes = results.getNumber("avgObjSize").longValue()
+        val estNumDocumentsPerPartition: Int = math.floor(partitionSizeInBytes.toFloat / avgObjSizeInBytes).toInt
+        val numberOfSamples = math.floor(samplesPerPartition * count / estNumDocumentsPerPartition.toFloat).toInt
+
+        val rightHandBoundaries = estNumDocumentsPerPartition >= count match {
+          case true => Seq.empty[BsonValue]
+          case false =>
+            val samples = connector.withCollectionDo(readConfig, {
+              coll: MongoCollection[BsonDocument] =>
+                coll.aggregate(List(
+                  Aggregates.sample(numberOfSamples),
+                  Aggregates.project(Projections.include(partitionKey)),
+                  Aggregates.sort(Sorts.ascending(partitionKey))
+                ).asJava).into(new util.ArrayList[BsonValue]()).asScala
+            })
+            samples.zipWithIndex.collect { case (_id, i) if i % samplesPerPartition == 0 => _id }
+        }
+
+        PartitionerHelper.createPartitions(partitionKey, rightHandBoundaries, PartitionerHelper.locations(connector))
+      case Failure(ex: MongoCommandException) if ex.getErrorMessage.endsWith("not found.") =>
+        logInfo(s"Could not find collection (${readConfig.collectionName}), using a single partition")
+        MongoSinglePartitioner.partitions(connector, readConfig)
+      case Failure(e) =>
+        logWarning(s"Could not get collection statistics. Server errmsg: ${e.getMessage}")
+        throw e
+    }
+  }
+}

--- a/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoShardedPartitioner.scala
+++ b/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoShardedPartitioner.scala
@@ -55,7 +55,7 @@ case object MongoShardedPartitioner extends MongoPartitioner {
         )
         MongoSinglePartitioner.partitions(connector, readConfig)
       case false =>
-        generatePartitions(chunks, readConfig.splitKey, mapShards(connector))
+        generatePartitions(chunks, readConfig.partitionKey, mapShards(connector))
     }
   }
 

--- a/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoSinglePartitioner.scala
+++ b/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoSinglePartitioner.scala
@@ -16,7 +16,7 @@
 
 package com.mongodb.spark.rdd.partitioner
 
-import org.bson.BsonDocument
+import org.bson.BsonValue
 import com.mongodb.spark.MongoConnector
 import com.mongodb.spark.config.ReadConfig
 
@@ -37,7 +37,7 @@ case object MongoSinglePartitioner extends MongoPartitioner {
     _partitions.isDefined match {
       case true => _partitions.get
       case false =>
-        _partitions = Some(PartitionerHelper.createPartitions(readConfig.partitionKey, Seq.empty[BsonDocument], PartitionerHelper.locations(connector)))
+        _partitions = Some(PartitionerHelper.createPartitions(readConfig.partitionKey, Seq.empty[BsonValue], PartitionerHelper.locations(connector)))
         _partitions.get
     }
   }

--- a/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoSinglePartitioner.scala
+++ b/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoSinglePartitioner.scala
@@ -30,6 +30,16 @@ import com.mongodb.spark.config.ReadConfig
  * @since 1.0
  */
 case object MongoSinglePartitioner extends MongoPartitioner {
-  override def partitions(connector: MongoConnector, readConfig: ReadConfig): Array[MongoPartition] =
-    Array(MongoPartition(0, new BsonDocument()))
+
+  private var _partitions: Option[Array[MongoPartition]] = None
+
+  override def partitions(connector: MongoConnector, readConfig: ReadConfig): Array[MongoPartition] = {
+    _partitions.isDefined match {
+      case true => _partitions.get
+      case false =>
+        _partitions = Some(PartitionerHelper.createPartitions(readConfig.partitionKey, Seq.empty[BsonDocument], PartitionerHelper.locations(connector)))
+        _partitions.get
+    }
+  }
+
 }

--- a/src/main/scala/com/mongodb/spark/rdd/partitioner/PartitionerHelper.scala
+++ b/src/main/scala/com/mongodb/spark/rdd/partitioner/PartitionerHelper.scala
@@ -16,9 +16,13 @@
 
 package com.mongodb.spark.rdd.partitioner
 
-import org.bson.{BsonDocument, BsonValue}
+import scala.collection.JavaConverters._
 
-private[partitioner] object PartitionerHelper {
+import org.bson._
+import com.mongodb.spark.MongoConnector
+import com.mongodb.spark.config.ReadConfig
+
+object PartitionerHelper {
 
   /**
    * Creates the upper and lower boundary query for the given key
@@ -30,5 +34,42 @@ private[partitioner] object PartitionerHelper {
    */
   def createBoundaryQuery(key: String, lower: BsonValue, upper: BsonValue): BsonDocument =
     new BsonDocument(key, new BsonDocument("$gte", lower).append("$lt", upper))
+
+  /**
+   * Creates partitions using a single Seq of documents representing the right handside of partitions
+   *
+   * @param partitionKey the key representing the partition most likely the `_id`.
+   * @param partitions the documents representing a split
+   * @param locations the optional server hostnames for the data
+   * @return
+   */
+  def createPartitions(partitionKey: String, partitions: Seq[BsonValue], locations: Seq[String] = Nil): Array[MongoPartition] = {
+    val minToMaxSplitKeys: Seq[BsonValue] = new BsonMinKey() +: partitions :+ new BsonMaxKey()
+    val partitionPairs: Seq[(BsonValue, BsonValue)] = minToMaxSplitKeys zip minToMaxSplitKeys.tail
+    partitionPairs.zipWithIndex.map({
+      case ((min: BsonValue, max: BsonValue), i: Int) => MongoPartition(i, createBoundaryQuery(partitionKey, min, max), locations)
+    }).toArray
+  }
+
+  /**
+   * Get the locations of the Mongo hosts
+   *
+   * @param connector the MongoConnector
+   * @return the locations
+   */
+  def locations(connector: MongoConnector): Seq[String] =
+    connector.withMongoClientDo(mongoClient => mongoClient.getAllAddress.asScala.map(_.getHost).distinct)
+
+  /**
+   * Runs the `collStats` command and returns the results
+   *
+   * @param connector the MongoConnector
+   * @param readConfig the readConfig
+   * @return the collStats result
+   */
+  def collStats(connector: MongoConnector, readConfig: ReadConfig): BsonDocument = {
+    val collStatsCommand: BsonDocument = new BsonDocument("collStats", new BsonString(readConfig.collectionName))
+    connector.withDatabaseDo(readConfig, { db => db.runCommand(collStatsCommand, readConfig.readPreference, classOf[BsonDocument]) })
+  }
 
 }

--- a/src/test/java/com/mongodb/spark/config/ReadConfigTest.java
+++ b/src/test/java/com/mongodb/spark/config/ReadConfigTest.java
@@ -46,8 +46,8 @@ public final class ReadConfigTest extends JavaRequiresMongoDB {
         options.put(ReadConfig.databaseNameProperty(), "db");
         options.put(ReadConfig.collectionNameProperty(), "collection");
         options.put(ReadConfig.sampleSizeProperty(), "500");
-        options.put(ReadConfig.maxChunkSizeProperty(), "99");
-        options.put(ReadConfig.splitKeyProperty(), "ID");
+        options.put(ReadConfig.partitionSizeMBProperty(), "99");
+        options.put(ReadConfig.partitionKeyProperty(), "ID");
         options.put(ReadConfig.localThresholdProperty(), "0");
         options.put(ReadConfig.readPreferenceNameProperty(), "secondaryPreferred");
         options.put(ReadConfig.readPreferenceTagSetsProperty(), "[{dc: \"east\", use: \"production\"},{}]");

--- a/src/test/scala/com/mongodb/spark/config/ReadConfigSpec.scala
+++ b/src/test/scala/com/mongodb/spark/config/ReadConfigSpec.scala
@@ -88,8 +88,8 @@ class ReadConfigSpec extends FlatSpec with Matchers {
       "database" -> "dbName",
       "collection" -> "collName",
       "uri" -> "mongodb://localhost/",
-      "maxchunksize" -> "20",
-      "splitkey" -> "foo",
+      "partitionsizemb" -> "20",
+      "partitionkey" -> "foo",
       "localthreshold" -> "10",
       "readpreference.name" -> "secondaryPreferred",
       "readpreference.tagsets" -> """[{dc:"east",use:"production"},{}]""",
@@ -126,8 +126,8 @@ class ReadConfigSpec extends FlatSpec with Matchers {
   val sparkConf = new SparkConf()
     .set("spark.mongodb.input.database", "db")
     .set("spark.mongodb.input.collection", "collection")
-    .set("spark.mongodb.input.maxChunkSize", "32")
-    .set("spark.mongodb.input.splitKey", "ID")
+    .set("spark.mongodb.input.partitionSizeMB", "32")
+    .set("spark.mongodb.input.partitionKey", "ID")
     .set("spark.mongodb.input.localThreshold", "0")
     .set("spark.mongodb.input.readPreference.name", "secondary")
     .set("spark.mongodb.input.readConcern.level", "local")

--- a/src/test/scala/com/mongodb/spark/rdd/partitioner/BsonValueOrderingSpec.scala
+++ b/src/test/scala/com/mongodb/spark/rdd/partitioner/BsonValueOrderingSpec.scala
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2016 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.spark.rdd.partitioner
+
+import scala.collection.JavaConverters._
+import scala.util.Random
+
+import org.bson.types.ObjectId
+import org.bson.{BsonDbPointer, _}
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class BsonValueOrderingSpec extends FlatSpec with Matchers {
+  // scalastyle:off magic.number
+
+  private val objectId = new ObjectId("000000000000000000000000")
+  private val allBsonTypesDocument: BsonDocument = {
+    val document = new BsonDocument()
+    document.put("nullValue", new BsonNull())
+    document.put("int32", new BsonInt32(42))
+    document.put("int64", new BsonInt64(52L))
+    document.put("boolean", new BsonBoolean(true))
+    document.put("date", new BsonDateTime(1463497097))
+    document.put("double", new BsonDouble(62.0))
+    document.put("string", new BsonString("spark connector"))
+    document.put("minKey", new BsonMinKey())
+    document.put("maxKey", new BsonMaxKey())
+    document.put("objectId", new BsonObjectId(objectId))
+    document.put("code", new BsonJavaScript("int i = 0;"))
+    document.put("codeWithScope", new BsonJavaScriptWithScope("int x = y", new BsonDocument("y", new BsonInt32(1))))
+    document.put("regex", new BsonRegularExpression("^test.*regex.*xyz$", "i"))
+    document.put("symbol", new BsonSymbol("ruby stuff"))
+    document.put("timestamp", new BsonTimestamp(0x12345678, 5))
+    document.put("undefined", new BsonUndefined())
+    document.put("binary", new BsonBinary(Array[Byte](5, 4, 3, 2, 1)))
+    document.put("oldBinary", new BsonBinary(BsonBinarySubType.OLD_BINARY, Array[Byte](1, 1, 1, 1, 1)))
+    document.put("arrayInt", new BsonArray(List(new BsonInt32(1), new BsonInt32(2), new BsonInt32(3)).asJava))
+    document.put("document", new BsonDocument("a", new BsonInt32(1)))
+    document.put("dbPointer", new BsonDbPointer("db.coll", objectId))
+    document
+  }
+  val allBsonTypes: Seq[(String, BsonValue)] = allBsonTypesDocument.entrySet().asScala.map(e => (e.getKey, e.getValue)).toSeq
+
+  val orderedKeys = Seq("minKey", "nullValue", "int32", "int64", "double", "symbol", "string", "document", "arrayInt", "binary",
+    "oldBinary", "objectId", "boolean", "date", "timestamp", "regex", "maxKey")
+
+  val undefinedOrderingKeys = Seq("dbPointer", "undefined", "code", "codeWithScope")
+
+  implicit object BsonValueOrdering extends BsonValueOrdering
+
+  "The BsonValueOrdering trait" should "order all bson types correctly" in {
+    val data = allBsonTypes.filter({ case kv => orderedKeys.contains(kv._1) }).map(_._2)
+    val ordered = Random.shuffle(data).sorted
+    ordered should equal(orderedKeys.map(allBsonTypesDocument.get(_)))
+  }
+
+  it should "compare numbers types correctly" in {
+    val data: Seq[BsonValue] = Seq(new BsonInt32(1), new BsonInt64(2), new BsonDouble(3.0), new BsonDouble(4.0), new BsonInt64(5), new BsonInt32(6))
+    val ordered = Random.shuffle(data).sorted
+    ordered should equal(data)
+  }
+
+  it should "compare string types correctly" in {
+    val data: Seq[BsonValue] = Seq(new BsonString("12345"), new BsonSymbol("a"), new BsonSymbol("b"), new BsonSymbol("c 1"),
+      new BsonString("c 2"), new BsonSymbol("d"), new BsonString("e"))
+    val ordered = Random.shuffle(data).sorted
+    ordered should equal(data)
+  }
+
+  it should "compare timestamp types correctly" in {
+    val data: Seq[BsonValue] = Seq(new BsonTimestamp(1, 5), new BsonTimestamp(1, 6), new BsonTimestamp(2, 1),
+      new BsonTimestamp(2, 10), new BsonTimestamp(3, 0), new BsonTimestamp(3, 1), new BsonTimestamp(10010101, 0))
+    val ordered = Random.shuffle(data).sorted
+    ordered should equal(data)
+  }
+
+  it should "compare binary types correctly" in {
+    val data: Seq[BsonValue] = Seq(
+      new BsonBinary(BsonBinarySubType.BINARY, Array[Byte](1, 1, 1, 1, 1)),
+      new BsonBinary(BsonBinarySubType.OLD_BINARY, Array[Byte](1, 1, 1, 1, 1)),
+      new BsonBinary(BsonBinarySubType.OLD_BINARY, Array[Byte](2, 2, 2, 2, 2, 2)),
+      new BsonBinary(BsonBinarySubType.OLD_BINARY, Array[Byte](2, 2, 2, 2, 2, 2, 2)),
+      new BsonBinary(BsonBinarySubType.OLD_BINARY, Array[Byte](2, 2, 2, 2, 2, 2, 3))
+    )
+    val ordered = Random.shuffle(data).sorted
+    ordered should equal(data)
+  }
+
+  it should "compare array types correctly" in {
+    val data: Seq[BsonValue] = Seq(
+      new BsonArray(List(new BsonInt32(1)).asJava),
+      new BsonArray(List(new BsonInt32(1), new BsonInt32(2)).asJava),
+      new BsonArray(List(new BsonInt32(1), new BsonInt32(2), new BsonInt32(3)).asJava),
+      new BsonArray(List(new BsonString("1")).asJava)
+    )
+    val ordered = Random.shuffle(data).sorted
+    ordered should equal(data)
+  }
+
+  it should "compare regex types correctly" in {
+    val data: Seq[BsonValue] = Seq(
+      new BsonRegularExpression(".*"),
+      new BsonRegularExpression(".*", "i"),
+      new BsonRegularExpression("[0-9a-z]+"),
+      new BsonRegularExpression("[a-z]+")
+    )
+    val ordered = Random.shuffle(data).sorted
+    ordered should equal(data)
+  }
+
+  it should "compare document types correctly" in {
+    val data: Seq[BsonValue] = Seq(
+      BsonDocument.parse("""{}"""),
+      BsonDocument.parse("""{a: 1}"""),
+      BsonDocument.parse("""{a: 1, b: 1}"""),
+      BsonDocument.parse("""{a: 2}"""),
+      BsonDocument.parse("""{a: "1"}""")
+    )
+    val ordered = Random.shuffle(data).sorted
+    ordered should equal(data)
+  }
+
+  it should "have no defined order for undefined types" in {
+    val data: Seq[BsonValue] = allBsonTypes.filter({ case kv => undefinedOrderingKeys.contains(kv._1) }).map(_._2)
+    val randomised = Random.shuffle(data)
+    val ordered = randomised.sorted
+    ordered should equal(randomised)
+  }
+  // scalastyle:on magic.number
+}

--- a/src/test/scala/com/mongodb/spark/rdd/partitioner/MongoPaginationPartitionerSpec.scala
+++ b/src/test/scala/com/mongodb/spark/rdd/partitioner/MongoPaginationPartitionerSpec.scala
@@ -16,28 +16,32 @@
 
 package com.mongodb.spark.rdd.partitioner
 
-import org.scalatest.FlatSpec
 import org.bson.{BsonDocument, BsonMaxKey, BsonMinKey, Document}
-import com.mongodb.spark.{JavaRequiresMongoDB, RequiresMongoDB}
+import com.mongodb.spark.RequiresMongoDB
 
-class MongoSplitVectorPartitionerSpec extends RequiresMongoDB {
+class MongoPaginationPartitionerSpec extends RequiresMongoDB {
 
   // scalastyle:off magic.number
-  "MongoSplitVectorPartitioner" should "partition the database as expected" in {
-    if (isSharded) cancel("Sharded MongoDB")
-    loadSampleData(5)
+  "MongoPaginationPartitioner" should "partition the database as expected" in {
+    loadSampleData(10)
 
-    val partitions = MongoSplitVectorPartitioner.partitions(mongoConnector, readConfig.copy(partitionSizeMB = 3))
-    partitions.length should be >= 2
+    val partitions = MongoPaginationPartitioner.partitions(mongoConnector, readConfig.copy(partitionSizeMB = 1))
+    partitions.length should equal(11)
     partitions.head.locations should not be empty
-    MongoSplitVectorPartitioner.partitions(mongoConnector, readConfig.copy(partitionSizeMB = 7)).length shouldBe 1
+
+    MongoPaginationPartitioner.partitions(mongoConnector, readConfig.copy(partitionSizeMB = 10)).length shouldBe 1
   }
   // scalastyle:on magic.number
 
   it should "have a default bounds of min to max key" in {
     val expectedBounds: BsonDocument = PartitionerHelper.createBoundaryQuery(readConfig.partitionKey, new BsonMinKey, new BsonMaxKey)
     collection.insertOne(new Document())
+    MongoPaginationPartitioner.partitions(mongoConnector, readConfig)(0).queryBounds should equal(expectedBounds)
+  }
 
-    MongoSplitVectorPartitioner.partitions(mongoConnector, readConfig)(0).queryBounds should equal(expectedBounds)
+  it should "handle no collection" in {
+    val expectedPartitions = MongoSinglePartitioner.partitions(mongoConnector, readConfig)
+    MongoPaginationPartitioner.partitions(mongoConnector, readConfig) should equal(expectedPartitions)
   }
 }
+

--- a/src/test/scala/com/mongodb/spark/rdd/partitioner/MongoPaginationPartitionerSpec.scala
+++ b/src/test/scala/com/mongodb/spark/rdd/partitioner/MongoPaginationPartitionerSpec.scala
@@ -16,8 +16,8 @@
 
 package com.mongodb.spark.rdd.partitioner
 
-import org.bson.{BsonDocument, BsonMaxKey, BsonMinKey, Document}
-import com.mongodb.spark.RequiresMongoDB
+import org.bson._
+import com.mongodb.spark.{MongoConnector, RequiresMongoDB}
 
 class MongoPaginationPartitionerSpec extends RequiresMongoDB {
 
@@ -25,11 +25,15 @@ class MongoPaginationPartitionerSpec extends RequiresMongoDB {
   "MongoPaginationPartitioner" should "partition the database as expected" in {
     loadSampleData(10)
 
+    val rightHandBoundaries = (1 to 100 by 10).map(x => new BsonString(f"$x%05d"))
+    val locations = PartitionerHelper.locations(MongoConnector(sparkConf))
+    val expectedPartitions = PartitionerHelper.createPartitions(readConfig.partitionKey, rightHandBoundaries, locations)
     val partitions = MongoPaginationPartitioner.partitions(mongoConnector, readConfig.copy(partitionSizeMB = 1))
-    partitions.length should equal(11)
-    partitions.head.locations should not be empty
 
-    MongoPaginationPartitioner.partitions(mongoConnector, readConfig.copy(partitionSizeMB = 10)).length shouldBe 1
+    partitions should equal(expectedPartitions)
+
+    val singlePartition = PartitionerHelper.createPartitions(readConfig.partitionKey, Seq.empty[BsonValue], locations)
+    MongoPaginationPartitioner.partitions(mongoConnector, readConfig.copy(partitionSizeMB = 10)) should equal(singlePartition)
   }
   // scalastyle:on magic.number
 

--- a/src/test/scala/com/mongodb/spark/rdd/partitioner/MongoSamplePartitionerSpec.scala
+++ b/src/test/scala/com/mongodb/spark/rdd/partitioner/MongoSamplePartitionerSpec.scala
@@ -28,9 +28,9 @@ class MongoSamplePartitionerSpec extends RequiresMongoDB {
     val rightHandBoundaries = (1 to 100 by 10).map(x => new BsonString(f"$x%05d"))
     val locations = PartitionerHelper.locations(MongoConnector(sparkConf))
     val expectedPartitions = PartitionerHelper.createPartitions(readConfig.partitionKey, rightHandBoundaries, locations)
-//    val partitions = MongoSamplePartitioner.partitions(mongoConnector, readConfig.copy(partitionSizeMB = 1))
-//
-//    partitions should equal(expectedPartitions)
+    //    val partitions = MongoSamplePartitioner.partitions(mongoConnector, readConfig.copy(partitionSizeMB = 1))
+    //
+    //    partitions should equal(expectedPartitions)
 
     val singlePartition = PartitionerHelper.createPartitions(readConfig.partitionKey, Seq.empty[BsonValue], locations)
     MongoSamplePartitioner.partitions(mongoConnector, readConfig.copy(partitionSizeMB = 10)) should equal(singlePartition)

--- a/src/test/scala/com/mongodb/spark/rdd/partitioner/MongoShardedPartitionerSpec.scala
+++ b/src/test/scala/com/mongodb/spark/rdd/partitioner/MongoShardedPartitionerSpec.scala
@@ -42,7 +42,7 @@ class MongoShardedPartitionerSpec extends RequiresMongoDB with PropertyChecks {
 
   it should "have a default bounds of min to max key" in {
     if (!isSharded) cancel("Not a Sharded MongoDB")
-    val expectedBounds: BsonDocument = new BsonDocument(readConfig.splitKey, new BsonDocument("$gte", new BsonMinKey).append("$lt", new BsonMaxKey))
+    val expectedBounds: BsonDocument = new BsonDocument(readConfig.partitionKey, new BsonDocument("$gte", new BsonMinKey).append("$lt", new BsonMaxKey))
     shardCollection()
     collection.insertOne(new Document())
 


### PR DESCRIPTION
Partition errors are now passed onto the user.
Partitioning non-existent collections still return a single partition.
Partition configs: `splitKey` renamed to `partitionKey`, `maxChunkSize` renamed to `partitionSizeMB`.
SplitVector partitioner no longer the default single node partitioner.

Added two new partitioners: MongoSamplePartitioner and MongoPaginationPartitioner

 * MongoSamplePartitioner uses over sampling and the average document size of a collection to calculate partitions
 * MongoPaginationPartitioner uses the average document size and queries to calculate partitions

SPARK-53 SPARK-54