### PR TITLE
Partitioner changes

### DIFF
--- a/doc/6-FAQ.md
+++ b/doc/6-FAQ.md
@@ -56,6 +56,26 @@ ssc.awaitTermination()
 
 Note: The Mongo Spark Connector only supports streams a sink.
 
+## What permissions do the partitioners require?
+
+Partitioner                         | Permissions required
+------------------------------------|-----------------------------------------------------------------------------------------
+`MongoFixedNumberPartitioner`       | Read collection
+`MongoPaginationPartitioner`        | Read collection
+`MongoSamplePartitioner`            | Read collection
+`MongoSinglePartitioner`            | Read collection
+`MongoShardedPartitioner`           | Read `config` database. Reads from the `chunks` and `shards` collections.
+`MongoSplitVectorPartitioner`       | Runs the `SplitVector` command. Requires `clusterManager` role or a custom permission.
+
+The `DefaultMongoPartitioner` is a special case as for sharded collections it uses the `MongoShardedPartitioner` otherwise for MongoDB 3.2+ 
+it will use the `MongoSamplePartitioner` but will fallback to the `MongoPaginationPartitioner` for older versions.
+
+
+## Unrecognized pipeline stage name: '$sample' error.
+
+In MongoDB deployments with mixed mongod versions, it is possible to get an `Unrecognized pipeline stage name: '$sample'` error.
+To mitigate this please explicitly configure which partitioner to use and explicitly define the Schema when using DataFrames.
+
 -----
 
 [Next - Changelog](7-Changelog.md)

--- a/doc/6-FAQ.md
+++ b/doc/6-FAQ.md
@@ -60,12 +60,13 @@ Note: The Mongo Spark Connector only supports streams a sink.
 
 Partitioner                         | Permissions required
 ------------------------------------|-----------------------------------------------------------------------------------------
-`MongoFixedNumberPartitioner`       | Read collection
-`MongoPaginationPartitioner`        | Read collection
+`DefaultMongoPartitioner`           | Read collection
 `MongoSamplePartitioner`            | Read collection
-`MongoSinglePartitioner`            | Read collection
 `MongoShardedPartitioner`           | Read `config` database. Reads from the `chunks` and `shards` collections.
+`MongoSinglePartitioner`            | Read collection
 `MongoSplitVectorPartitioner`       | Runs the `SplitVector` command. Requires `clusterManager` role or a custom permission.
+`MongoPaginateByCountPartitioner`   | Read collection
+`MongoPaginateBySizePartitioner`    | Read collection
 
 The `DefaultMongoPartitioner` is a special case as for sharded collections it uses the `MongoShardedPartitioner` otherwise for MongoDB 3.2+ 
 it will use the `MongoSamplePartitioner` but will fallback to the `MongoPaginationPartitioner` for older versions.

--- a/doc/7-Changelog.md
+++ b/doc/7-Changelog.md
@@ -1,6 +1,10 @@
 # Mongo Spark Connector Changelog
 
 ## 0.4
+  * [[SPARK-60](https://jira.mongodb.org/browse/SPARK-60)] Added partitioner to ReadConfig. Added custom partitioner options.
+  * [[SPARK-54](https://jira.mongodb.org/browse/SPARK-54)] Added a sample and pagination based partitioners. SplitVector no longer a default partitioner.
+  * [[SPARK-53](https://jira.mongodb.org/browse/SPARK-53)] Partition failures now explicitly thrown.
+  * [[SPARK-51](https://jira.mongodb.org/browse/SPARK-51)] Documented partition permissions required.
   * [[SPARK-61](https://jira.mongodb.org/browse/SPARK-61)] Ensure that MongoSpark builder applies overridden options correctly.
 
 ## 0.3

--- a/src/main/scala/com/mongodb/spark/config/MongoInputConfig.scala
+++ b/src/main/scala/com/mongodb/spark/config/MongoInputConfig.scala
@@ -38,8 +38,8 @@ package com.mongodb.spark.config
  *  - [[readPreferenceTagSetsProperty readPreference.tagSets]], the `ReadPreference` TagSets to use.
  *  - [[readConcernLevelProperty readConcern.level]], the `ReadConcern` level to use.
  *  - [[sampleSizeProperty sampleSize]], the sample size to use when inferring the schema.
- *  - [[splitKeyProperty splitKey]], the partition key to split the data.
- *  - [[maxChunkSizeProperty maxChunkSize]], the maximum chunk size when partitioning data from an unsharded collection.
+ *  - [[partitionerProperty partitioner]], the name of the partitioner to use to partition the data.
+ *  - [[partitionerOptionsProperty partitionerOptions]], the custom options used to configure the partitioner.
  *  - [[localThresholdProperty localThreshold]], the number of milliseconds used when choosing among multiple MongoDB servers to send a request.
  *
  */
@@ -60,7 +60,7 @@ trait MongoInputConfig extends MongoCompanionConfig {
   /**
    * The `ReadPreference` name property
    *
-   * Default: `ACKNOWLEDGED`
+   * Default: `primary`
    * @see [[ReadPreferenceConfig]]
    */
   val readPreferenceNameProperty = "readPreference.name".toLowerCase
@@ -75,6 +75,7 @@ trait MongoInputConfig extends MongoCompanionConfig {
   /**
    * The `ReadConcern` level property
    *
+   * Default: `DEFAULT`
    * @see [[ReadConcernConfig]]
    */
   val readConcernLevelProperty = "readConcern.level".toLowerCase
@@ -88,20 +89,20 @@ trait MongoInputConfig extends MongoCompanionConfig {
   val sampleSizeProperty = "sampleSize".toLowerCase
 
   /**
-   * The split key property
+   * The partition property
    *
-   * Represents the key to be used when partitioning the data in the collection.
-   * Default: `_id`
+   * Represents the name of the partitioner to use when partitioning the data in the collection.
+   * Default: `MongoDefaultPartitioner`
    */
-  val splitKeyProperty = "splitKey".toLowerCase
+  val partitionerProperty = "partitioner".toLowerCase
 
   /**
-   * The max chunk size property
+   * The partitioner options property
    *
-   * Represents the max size (in MB) for each partition. Only used when partitioning non-sharded collections.
-   * Default: `64`
+   * Represents a map of options for customising the configuration of a partitioner.
+   * Default: `Map.empty[String, String]`
    */
-  val maxChunkSizeProperty = "maxChunkSize".toLowerCase
+  val partitionerOptionsProperty = "partitionerOptions".toLowerCase
 
   /**
    * The localThreshold property

--- a/src/main/scala/com/mongodb/spark/config/ReadConfig.scala
+++ b/src/main/scala/com/mongodb/spark/config/ReadConfig.scala
@@ -196,7 +196,7 @@ case class ReadConfig(
       ReadConfig.sampleSizeProperty -> sampleSize.toString,
       ReadConfig.partitionerProperty -> partitioner.getClass.getName,
       ReadConfig.localThresholdProperty -> localThreshold.toString
-    ) ++ partitionerOptions.map(kv => (s"${ReadConfig.partitionerOptionsProperty}.${kv._1}", kv._2)) ++
+    ) ++ partitionerOptions.map(kv => (s"${ReadConfig.partitionerOptionsProperty}.${kv._1}".toLowerCase, kv._2)) ++
       readPreferenceConfig.asOptions ++ readConcernConfig.asOptions
 
     connectionString match {
@@ -204,27 +204,6 @@ case class ReadConfig(
       case None      => options
     }
   }
-
-  // scalastyle:off parameter.number
-  /**
-   * Copies the ReadConfig
-   */
-  def copy(
-    databaseName:         String                         = databaseName,
-    collectionName:       String                         = collectionName,
-    connectionString:     Option[String]                 = connectionString,
-    sampleSize:           Int                            = sampleSize,
-    partitioner:          MongoPartitioner               = partitioner,
-    partitionerOptions:   collection.Map[String, String] = partitionerOptions,
-    localThreshold:       Int                            = localThreshold,
-    readPreferenceConfig: ReadPreferenceConfig           = readPreferenceConfig,
-    readConcernConfig:    ReadConcernConfig              = readConcernConfig
-  ): ReadConfig = {
-
-    new ReadConfig(databaseName, collectionName, connectionString, sampleSize, partitioner,
-      partitionerOptions.map(kv => (kv._1.toLowerCase, kv._2)), localThreshold, readPreferenceConfig, readConcernConfig)
-  }
-  // scalastyle:on parameter.number
 
   override def withOptions(options: util.Map[String, String]): ReadConfig = withOptions(options.asScala)
 

--- a/src/main/scala/com/mongodb/spark/config/ReadConfig.scala
+++ b/src/main/scala/com/mongodb/spark/config/ReadConfig.scala
@@ -18,14 +18,16 @@ package com.mongodb.spark.config
 
 import java.util
 
-import com.mongodb.spark.notNull
-import com.mongodb.{ConnectionString, ReadConcern, ReadPreference}
-import org.apache.spark.SparkConf
-import org.apache.spark.api.java.JavaSparkContext
 import scala.collection.JavaConverters._
 import scala.util.Try
 
+import org.apache.spark.SparkConf
+import org.apache.spark.api.java.JavaSparkContext
 import org.apache.spark.sql.SQLContext
+
+import com.mongodb.spark.rdd.partitioner.{DefaultMongoPartitioner, MongoPartitioner}
+import com.mongodb.spark.{LoggingTrait, notNull}
+import com.mongodb.{ConnectionString, ReadConcern, ReadPreference}
 
 /**
  * The `ReadConfig` companion object
@@ -34,28 +36,32 @@ import org.apache.spark.sql.SQLContext
  *
  * @since 1.0
  */
-object ReadConfig extends MongoInputConfig {
+object ReadConfig extends MongoInputConfig with LoggingTrait {
 
   type Self = ReadConfig
 
   private val DefaultSampleSize: Int = 1000
-  private val DefaultMaxChunkSize = 64 // 64 MB
-  private val DefaultSplitKey = "_id"
+  private val DefaultPartitioner = DefaultMongoPartitioner
+  private val DefaultPartitionerOptions = Map.empty[String, String]
+  private val DefaultPartitionerPath = "com.mongodb.spark.rdd.partitioner."
 
   override def apply(options: collection.Map[String, String], default: Option[ReadConfig]): ReadConfig = {
     val cleanedOptions = stripPrefix(options)
     val cachedConnectionString = connectionString(cleanedOptions)
     val defaultDatabase = default.map(conf => conf.databaseName).orElse(Option(cachedConnectionString.getDatabase))
     val defaultCollection = default.map(conf => conf.collectionName).orElse(Option(cachedConnectionString.getCollection))
-    ReadConfig(
+    val defaultPartitioner = default.map(conf => conf.partitioner).getOrElse(DefaultPartitioner)
+    val defaultPartitionerOptions = default.map(conf => conf.partitionerOptions).getOrElse(DefaultPartitionerOptions)
+    val partitionerOptions = defaultPartitionerOptions ++ getPartitionerOptions(cleanedOptions)
+
+    new ReadConfig(
       databaseName = databaseName(databaseNameProperty, cleanedOptions, defaultDatabase),
       collectionName = collectionName(collectionNameProperty, cleanedOptions, defaultCollection),
       connectionString = cleanedOptions.get(mongoURIProperty).orElse(default.flatMap(conf => conf.connectionString)),
       sampleSize = getInt(cleanedOptions.get(sampleSizeProperty), default.map(conf => conf.sampleSize), DefaultSampleSize),
-      maxChunkSize = getInt(cleanedOptions.get(maxChunkSizeProperty), default.map(conf => conf.maxChunkSize), DefaultMaxChunkSize),
-      splitKey = getString(cleanedOptions.get(splitKeyProperty), default.map(conf => conf.splitKey), DefaultSplitKey),
-      localThreshold = getInt(cleanedOptions.get(localThresholdProperty), default.map(conf => conf.localThreshold),
-        MongoSharedConfig.DefaultLocalThreshold),
+      partitioner = cleanedOptions.get(partitionerProperty).map(getPartitioner).getOrElse(defaultPartitioner),
+      partitionerOptions = partitionerOptions,
+      localThreshold = getInt(cleanedOptions.get(localThresholdProperty), default.map(conf => conf.localThreshold), MongoSharedConfig.DefaultLocalThreshold),
       readPreferenceConfig = ReadPreferenceConfig(cleanedOptions, default.map(conf => conf.readPreferenceConfig)),
       readConcernConfig = ReadConcernConfig(cleanedOptions, default.map(conf => conf.readConcernConfig))
     )
@@ -69,8 +75,8 @@ object ReadConfig extends MongoInputConfig {
    * @param collectionName the collection name
    * @param connectionString the optional connection string used in the creation of this configuration
    * @param sampleSize a positive integer sample size to draw from the collection when inferring the schema
-   * @param maxChunkSize   the maximum chunkSize for non-sharded collections
-   * @param splitKey the key to split the collection by for non-sharded collections or the "shard key" for sharded collection
+   * @param partitioner the class name of the partitioner to use to create partitions
+   * @param partitionerOptions the configuration options for the partitioner
    * @param localThreshold the local threshold in milliseconds used when choosing among multiple MongoDB servers to send a request.
    *                       Only servers whose ping time is less than or equal to the server with the fastest ping time plus the local
    *                       threshold will be chosen.
@@ -78,16 +84,17 @@ object ReadConfig extends MongoInputConfig {
    * @param readConcern the readConcern configuration
    * @since 1.0
    */
-  def create(databaseName: String, collectionName: String, connectionString: String, sampleSize: Int, maxChunkSize: Int, splitKey: String,
-             localThreshold: Int, readPreference: ReadPreference, readConcern: ReadConcern): ReadConfig = {
+  def create(databaseName: String, collectionName: String, connectionString: String, sampleSize: Int,
+             partitioner: String, partitionerOptions: util.Map[String, String], localThreshold: Int, readPreference: ReadPreference,
+             readConcern: ReadConcern): ReadConfig = {
     notNull("databaseName", databaseName)
     notNull("collectionName", collectionName)
-    notNull("splitKey", splitKey)
+    notNull("partitioner", partitioner)
     notNull("readPreference", readPreference)
     notNull("readConcern", readConcern)
 
-    new ReadConfig(databaseName, collectionName, Option(connectionString), sampleSize, maxChunkSize, splitKey, localThreshold,
-      ReadPreferenceConfig.apply(readPreference), ReadConcernConfig.apply(readConcern))
+    new ReadConfig(databaseName, collectionName, Option(connectionString), sampleSize, getPartitioner(partitioner),
+      getPartitionerOptions(partitionerOptions.asScala), localThreshold, ReadPreferenceConfig(readPreference), ReadConcernConfig(readConcern))
   }
   // scalastyle:on parameter.number
 
@@ -122,6 +129,27 @@ object ReadConfig extends MongoInputConfig {
     notNull("options", options)
     apply(sparkConf, options.asScala)
   }
+
+  private def getPartitioner(partitionerName: String): MongoPartitioner = {
+    val partitionerClassName = if (partitionerName.contains(".")) partitionerName else s"$DefaultPartitionerPath$partitionerName"
+    val parsedPartitioner = Try({
+      val clazz = Class.forName(partitionerClassName)
+      partitionerClassName.endsWith("$") match {
+        case true  => clazz.getField("MODULE$").get(clazz).asInstanceOf[MongoPartitioner]
+        case false => clazz.newInstance().asInstanceOf[MongoPartitioner]
+      }
+    })
+    if (parsedPartitioner.isFailure) {
+      logWarning(s"Could not load the partitioner: '$partitionerName'. Please check the namespace is correct.")
+      throw parsedPartitioner.failed.get
+    }
+    parsedPartitioner.get
+  }
+
+  private def getPartitionerOptions(options: collection.Map[String, String]): collection.Map[String, String] = {
+    stripPrefix(options).map(kv => (kv._1.toLowerCase, kv._2))
+      .filter(kv => kv._1.startsWith(partitionerOptionsProperty)).map(kv => (kv._1.stripPrefix(s"$partitionerOptionsProperty."), kv._2))
+  }
 }
 
 /**
@@ -131,26 +159,25 @@ object ReadConfig extends MongoInputConfig {
  * @param collectionName the collection name
  * @param connectionString the optional connection string used in the creation of this configuration
  * @param sampleSize a positive integer sample size to draw from the collection when inferring the schema
- * @param maxChunkSize   the maximum chunkSize for non-sharded collections
- * @param splitKey the key to split the collection by for non-sharded collections or the "shard key" for sharded collection
+ * @param partitioner the class name of the partitioner to use to create partitions
+ * @param partitionerOptions the configuration options for the partitioner
  * @param localThreshold the local threshold in milliseconds used when choosing among multiple MongoDB servers to send a request.
  *                       Only servers whose ping time is less than or equal to the server with the fastest ping time plus the local
  *                       threshold will be chosen.
  * @param readPreferenceConfig the readPreference configuration
  * @param readConcernConfig the readConcern configuration
- *
  * @since 1.0
  */
 case class ReadConfig(
     databaseName:         String,
     collectionName:       String,
-    connectionString:     Option[String]       = None,
-    sampleSize:           Int                  = ReadConfig.DefaultSampleSize,
-    maxChunkSize:         Int                  = ReadConfig.DefaultMaxChunkSize,
-    splitKey:             String               = ReadConfig.DefaultSplitKey,
-    localThreshold:       Int                  = MongoSharedConfig.DefaultLocalThreshold,
-    readPreferenceConfig: ReadPreferenceConfig = ReadPreferenceConfig(),
-    readConcernConfig:    ReadConcernConfig    = ReadConcernConfig()
+    connectionString:     Option[String]                 = None,
+    sampleSize:           Int                            = ReadConfig.DefaultSampleSize,
+    partitioner:          MongoPartitioner               = ReadConfig.DefaultPartitioner,
+    partitionerOptions:   collection.Map[String, String] = ReadConfig.DefaultPartitionerOptions,
+    localThreshold:       Int                            = MongoSharedConfig.DefaultLocalThreshold,
+    readPreferenceConfig: ReadPreferenceConfig           = ReadPreferenceConfig(),
+    readConcernConfig:    ReadConcernConfig              = ReadConcernConfig()
 ) extends MongoCollectionConfig with MongoClassConfig {
   require(Try(connectionString.map(uri => new ConnectionString(uri))).isSuccess, s"Invalid uri: '${connectionString.get}'")
   require(sampleSize > 0, s"sampleSize ($sampleSize) must be greater than 0")
@@ -167,16 +194,37 @@ case class ReadConfig(
       ReadConfig.databaseNameProperty -> databaseName,
       ReadConfig.collectionNameProperty -> collectionName,
       ReadConfig.sampleSizeProperty -> sampleSize.toString,
-      ReadConfig.maxChunkSizeProperty -> maxChunkSize.toString,
-      ReadConfig.splitKeyProperty -> splitKey,
+      ReadConfig.partitionerProperty -> partitioner.getClass.getName,
       ReadConfig.localThresholdProperty -> localThreshold.toString
-    ) ++ readPreferenceConfig.asOptions ++ readConcernConfig.asOptions
+    ) ++ partitionerOptions.map(kv => (s"${ReadConfig.partitionerOptionsProperty}.${kv._1}", kv._2)) ++
+      readPreferenceConfig.asOptions ++ readConcernConfig.asOptions
 
     connectionString match {
       case Some(uri) => options + (ReadConfig.mongoURIProperty -> uri)
       case None      => options
     }
   }
+
+  // scalastyle:off parameter.number
+  /**
+   * Copies the ReadConfig
+   */
+  def copy(
+    databaseName:         String                         = databaseName,
+    collectionName:       String                         = collectionName,
+    connectionString:     Option[String]                 = connectionString,
+    sampleSize:           Int                            = sampleSize,
+    partitioner:          MongoPartitioner               = partitioner,
+    partitionerOptions:   collection.Map[String, String] = partitionerOptions,
+    localThreshold:       Int                            = localThreshold,
+    readPreferenceConfig: ReadPreferenceConfig           = readPreferenceConfig,
+    readConcernConfig:    ReadConcernConfig              = readConcernConfig
+  ): ReadConfig = {
+
+    new ReadConfig(databaseName, collectionName, connectionString, sampleSize, partitioner,
+      partitionerOptions.map(kv => (kv._1.toLowerCase, kv._2)), localThreshold, readPreferenceConfig, readConcernConfig)
+  }
+  // scalastyle:on parameter.number
 
   override def withOptions(options: util.Map[String, String]): ReadConfig = withOptions(options.asScala)
 

--- a/src/main/scala/com/mongodb/spark/exceptions/MongoPartitionerException.scala
+++ b/src/main/scala/com/mongodb/spark/exceptions/MongoPartitionerException.scala
@@ -19,9 +19,9 @@ package com.mongodb.spark.exceptions
 import com.mongodb.MongoException
 
 /**
- * A class for exceptions that come from the connector's MongoDB splitters.
+ * A class for exceptions that come from the connector's MongoDB partitioners.
  */
-class MongoSplitException(message: String, throwable: Throwable) extends MongoException(message, throwable) {
+class MongoPartitionerException(message: String, throwable: Throwable) extends MongoException(message, throwable) {
 
   def this(message: String) {
     this(message, null) // scalastyle:ignore

--- a/src/main/scala/com/mongodb/spark/rdd/partitioner/BsonValueOrdering.scala
+++ b/src/main/scala/com/mongodb/spark/rdd/partitioner/BsonValueOrdering.scala
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2016 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.spark.rdd.partitioner
+
+import scala.annotation.tailrec
+import scala.collection.JavaConverters._
+
+import org.bson._
+
+trait BsonValueOrdering extends Ordering[BsonValue] {
+
+  // scalastyle:off cyclomatic.complexity
+  private val bsonTypeComparisonMap: Map[BsonType, Int] = Map(
+    BsonType.MIN_KEY -> 1,
+    BsonType.NULL -> 2,
+    BsonType.INT32 -> 3,
+    BsonType.INT64 -> 3,
+    BsonType.DOUBLE -> 3,
+    BsonType.SYMBOL -> 4,
+    BsonType.STRING -> 4,
+    BsonType.DOCUMENT -> 5,
+    BsonType.ARRAY -> 6,
+    BsonType.BINARY -> 7,
+    BsonType.OBJECT_ID -> 8,
+    BsonType.BOOLEAN -> 9,
+    BsonType.DATE_TIME -> 10,
+    BsonType.TIMESTAMP -> 11,
+    BsonType.REGULAR_EXPRESSION -> 12,
+    BsonType.MAX_KEY -> 13
+  )
+
+  /**
+   *
+   * Returns an integer whose sign communicates how x compares to y.
+   *
+   * The result sign has the following meaning:
+   *
+   * - negative if x < y
+   * - positive if x > y
+   * - zero otherwise (if x == y)
+   *
+   * When comparing values of different BSON types, MongoDB uses the following comparison order, from lowest to highest:
+   *
+   * 1. MinKey (internal type)
+   * 2. Null
+   * 3. Numbers (ints, longs, doubles)
+   * 4. Symbol, String
+   * 5. Object
+   * 6. Array
+   * 7. BinData
+   * 8. ObjectId
+   * 9. Boolean
+   * 10. Date
+   * 11. Timestamp
+   * 12. Regular Expression
+   * 13. MaxKey (internal type)
+   */
+  override def compare(x: BsonValue, y: BsonValue): Int = {
+    (x.getBsonType, y.getBsonType) match {
+      case (BsonType.MIN_KEY, BsonType.MIN_KEY)     => 0
+      case (BsonType.NULL, BsonType.NULL)           => 0
+      case (isBsonNumber(), isBsonNumber())         => compareNumbers(x.asNumber, y.asNumber)
+      case (isString(), isString())                 => compareStrings(x, y)
+      case (BsonType.DOCUMENT, BsonType.DOCUMENT)   => compareDocuments(x.asDocument, y.asDocument)
+      case (BsonType.ARRAY, BsonType.ARRAY)         => compareArrays(x.asArray, y.asArray)
+      case (BsonType.BINARY, BsonType.BINARY)       => compareBinary(x.asBinary, y.asBinary)
+      case (BsonType.OBJECT_ID, BsonType.OBJECT_ID) => x.asObjectId.getValue.compareTo(y.asObjectId.getValue)
+      case (BsonType.BOOLEAN, BsonType.BOOLEAN)     => x.asBoolean.getValue.compareTo(y.asBoolean().getValue)
+      case (BsonType.DATE_TIME, BsonType.DATE_TIME) => x.asDateTime.getValue.compareTo(y.asDateTime().getValue)
+      case (BsonType.TIMESTAMP, BsonType.TIMESTAMP) => compareTimestamps(x.asTimestamp, y.asTimestamp)
+      case (BsonType.REGULAR_EXPRESSION, BsonType.REGULAR_EXPRESSION) =>
+        compareRegularExpressions(x.asRegularExpression, y.asRegularExpression)
+      case (xType, yType) =>
+        val xSortScore = bsonTypeComparisonMap.getOrElse(x.getBsonType, 14) // scalastyle:ignore
+        val ySortScore = bsonTypeComparisonMap.getOrElse(y.getBsonType, 14) // scalastyle:ignore
+        xSortScore.compareTo(ySortScore)
+    }
+  }
+
+  private def compareDocuments(x: BsonDocument, y: BsonDocument): Int = {
+    val xKeyValues: Seq[(String, BsonValue)] = documentKeyValues(x)
+    val yKeyValues: Seq[(String, BsonValue)] = documentKeyValues(y)
+
+    compareKeyValues(xKeyValues zip yKeyValues) match {
+      case 0 => xKeyValues.length.compareTo(yKeyValues.length)
+      case v => v
+    }
+  }
+
+  private def compareArrays(x: BsonArray, y: BsonArray): Int = {
+    compareBsonValues(x.getValues.asScala zip y.getValues.asScala) match {
+      case 0 => x.getValues.size.compareTo(y.getValues.size)
+      case v => v
+    }
+  }
+
+  private def compareRegularExpressions(x: BsonRegularExpression, y: BsonRegularExpression): Int = {
+    x.getPattern.compareTo(y.getPattern) match {
+      case 0 => x.getOptions.compareTo(y.getOptions)
+      case v => v
+    }
+  }
+
+  private def compareBinary(x: BsonBinary, y: BsonBinary): Int = {
+    x.getData.length.compareTo(y.getData.length) match {
+      case 0 =>
+        x.getType.compareTo(y.getType) match {
+          case 0 => compareBytes(x.getData zip y.getData)
+          case v => v
+        }
+      case v => v
+    }
+  }
+
+  private def compareTimestamps(x: BsonTimestamp, y: BsonTimestamp): Int = {
+    x.getTime.compareTo(y.getTime) match {
+      case 0 => x.getInc.compareTo(y.getInc)
+      case v => v
+    }
+  }
+
+  @tailrec
+  private def compareKeyValues(kvs: Seq[((String, BsonValue), (String, BsonValue))]): Int = {
+    kvs.headOption match {
+      case Some(kv) => compareKeyValues(kv._1, kv._2) match {
+        case 0 => compareKeyValues(kvs.tail)
+        case v => v
+      }
+      case None => 0
+    }
+  }
+
+  private def compareKeyValues(x: (String, BsonValue), y: (String, BsonValue)): Int = {
+    x._1.compareTo(y._1) match {
+      case 0 => compare(x._2, y._2)
+      case v => v
+    }
+  }
+
+  @tailrec
+  private def compareBsonValues(values: Seq[(BsonValue, BsonValue)]): Int = {
+    values.headOption match {
+      case Some(value) => compare(value._1, value._2) match {
+        case 0 => compareBsonValues(values.tail)
+        case v => v
+      }
+      case None => 0
+    }
+  }
+
+  @tailrec
+  private def compareBytes(values: Seq[(Byte, Byte)]): Int = {
+    values.headOption match {
+      case Some(value) => value._1.compareTo(value._2) match {
+        case 0 => compareBytes(values.tail)
+        case v => v
+      }
+      case None => 0
+    }
+  }
+
+  private def compareStrings(x: BsonValue, y: BsonValue): Int = {
+    val (xString, yString) = (x.getBsonType, y.getBsonType) match {
+      case (BsonType.STRING, BsonType.STRING) => (x.asString.getValue, y.asString.getValue)
+      case (BsonType.SYMBOL, BsonType.STRING) => (x.asSymbol.getSymbol, y.asString.getValue)
+      case (BsonType.STRING, BsonType.SYMBOL) => (x.asString.getValue, y.asSymbol.getSymbol)
+      case (BsonType.SYMBOL, BsonType.SYMBOL) => (x.asSymbol.getSymbol, y.asSymbol.getSymbol)
+      case _                                  => throw new UnsupportedOperationException(s"Cannot compare $x with $y. Not string compatible types.")
+    }
+    compareBytes(xString.getBytes("utf-8") zip yString.getBytes("utf-8"))
+  }
+
+  private def compareNumbers(x: BsonNumber, y: BsonNumber): Int = {
+    (x.getBsonType, y.getBsonType) match {
+      case (BsonType.INT64, BsonType.DOUBLE) => compareLongToDouble(x.longValue, y.doubleValue)
+      case (BsonType.DOUBLE, BsonType.INT64) => -compareLongToDouble(y.longValue, x.doubleValue)
+      case _                                 => x.doubleValue.compareTo(y.doubleValue)
+    }
+  }
+
+  private def compareLongToDouble(x: Long, y: Double): Int = {
+    val END_OF_PRECISE_DOUBLES: Double = 1 << 53 // positive 2**63
+    val BOUND_OF_LONG_RANGE: Double = -Long.MinValue.toDouble
+
+    if (y.compareTo(Double.NaN) == 0) {
+      // All Longs are > NaN
+      1
+    } else if (x <= END_OF_PRECISE_DOUBLES && x >= -END_OF_PRECISE_DOUBLES) {
+      // Ints with magnitude <= 2**53 can be precisely represented as doubles.
+      // Additionally, doubles outside of this range can't have a fractional component.
+      x.toDouble.compareTo(y)
+    } else if (y >= BOUND_OF_LONG_RANGE) {
+      // Large magnitude doubles (including +/- Inf) are strictly > or < all Longs.
+      // Can't be represented in a Long.
+      -1
+    } else if (y < -BOUND_OF_LONG_RANGE) {
+      1 // Can be represented in a Long.
+    } else {
+      // Remaining Doubles can have their integer component precisely represented as longs.
+      // If they have a fractional component, they must be strictly > or < lhs even after
+      // truncation of the fractional component since low-magnitude lhs were handled above.
+      x.compareTo(y.toLong)
+    }
+  }
+
+  private def documentKeyValues(document: BsonDocument): Seq[(String, BsonValue)] = {
+    val it = document.entrySet().iterator()
+    new Iterator[(String, BsonValue)] {
+      override def hasNext = it.hasNext
+      override def next() = {
+        val next = it.next()
+        (next.getKey, next.getValue)
+      }
+    }.toSeq
+  }
+
+  private object isBsonNumber {
+    val bsonNumberTypes = Set(BsonType.INT32, BsonType.INT64, BsonType.DOUBLE)
+
+    def unapply(x: BsonType): Boolean = bsonNumberTypes.contains(x)
+  }
+
+  private object isString {
+    val bsonNumberTypes = Set(BsonType.SYMBOL, BsonType.STRING)
+
+    def unapply(x: BsonType): Boolean = bsonNumberTypes.contains(x)
+  }
+
+}
+
+// scalastyle:on cyclomatic.complexity

--- a/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoPaginateByCountPartitioner.scala
+++ b/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoPaginateByCountPartitioner.scala
@@ -80,8 +80,7 @@ class MongoPaginateByCountPartitioner extends MongoPartitioner with MongoPaginat
           logWarning("Inefficient partitioning, creating a partition per document. Decrease the `numberOfPartitions` property.")
         }
 
-        val skipValues = (0 to numberOfPartitions.toInt).map(i => i * numDocumentsPerPartition)
-        val rightHandBoundaries = calculateSkipPartitions(connector, readConfig, partitionKey, count, skipValues)
+        val rightHandBoundaries = calculatePartitions(connector, readConfig, partitionKey, count, numDocumentsPerPartition)
         PartitionerHelper.createPartitions(partitionKey, rightHandBoundaries, PartitionerHelper.locations(connector))
       case Failure(ex: MongoCommandException) if ex.getErrorMessage.endsWith("not found.") =>
         logInfo(s"Could not find collection (${readConfig.collectionName}), using a single partition")

--- a/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoPaginateByCountPartitioner.scala
+++ b/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoPaginateByCountPartitioner.scala
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2016 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.spark.rdd.partitioner
+
+import scala.collection.immutable.IndexedSeq
+import scala.util.{Failure, Success, Try}
+
+import org.bson.{BsonDocument, BsonValue}
+import com.mongodb.MongoCommandException
+import com.mongodb.client.MongoCollection
+import com.mongodb.client.model.{Projections, Sorts}
+import com.mongodb.spark.MongoConnector
+import com.mongodb.spark.config.ReadConfig
+
+/**
+ * The pagination by count partitioner.
+ *
+ * Paginates the collection into a maximum number of partitions.
+ *
+ * $configurationProperties
+ *
+ *  - [[partitionKeyProperty partitionkey]], the field to partition the collection by. The field should be indexed and contain unique values.
+ *     Defaults to `_id`.
+ *  - [[numberOfPartitionsProperty numberofpartitions]], the maximum number of partitions to create. Defaults to `64`.
+ *
+ *
+ * '''Note:''' This can be a expensive operation as it creates 1 cursor for every partition.
+ *
+ * @since 1.0
+ */
+class MongoPaginateByCountPartitioner extends MongoPartitioner with MongoPaginationPartitioner {
+
+  private implicit object BsonValueOrdering extends BsonValueOrdering
+  private val DefaultPartitionKey = "_id"
+  private val DefaultNumberOfPartitions = "64"
+
+  /**
+   * The partition key property
+   */
+  val partitionKeyProperty = "partitionKey".toLowerCase()
+
+  /**
+   * The number of partitions property
+   */
+  val numberOfPartitionsProperty = "numberOfPartitions".toLowerCase()
+
+  /**
+   * Calculate the Partitions
+   *
+   * @param connector  the MongoConnector
+   * @param readConfig the [[com.mongodb.spark.config.ReadConfig]]
+   * @return the partitions
+   */
+  override def partitions(connector: MongoConnector, readConfig: ReadConfig, pipeline: Array[BsonDocument]): Array[MongoPartition] = {
+
+    Try(PartitionerHelper.collStats(connector, readConfig)) match {
+      case Success(results) =>
+        val partitionKey = readConfig.partitionerOptions.getOrElse(partitionKeyProperty, DefaultPartitionKey)
+        val maxNumberOfPartitions = readConfig.partitionerOptions.getOrElse(numberOfPartitionsProperty, DefaultNumberOfPartitions).toInt
+        val count = results.getNumber("count").longValue()
+        val numberOfPartitions = if (count < maxNumberOfPartitions) count else maxNumberOfPartitions
+        val numDocumentsPerPartition = math.floor(count / numberOfPartitions).toInt
+
+        if (count == numberOfPartitions) {
+          logWarning("Inefficient partitioning, creating a partition per document. Decrease the `numberOfPartitions` property.")
+        }
+
+        val skipValues = (0 to numberOfPartitions.toInt).map(i => i * numDocumentsPerPartition)
+        val rightHandBoundaries = calculateSkipPartitions(connector, readConfig, partitionKey, count, skipValues)
+        PartitionerHelper.createPartitions(partitionKey, rightHandBoundaries, PartitionerHelper.locations(connector))
+      case Failure(ex: MongoCommandException) if ex.getErrorMessage.endsWith("not found.") =>
+        logInfo(s"Could not find collection (${readConfig.collectionName}), using a single partition")
+        MongoSinglePartitioner.partitions(connector, readConfig, pipeline)
+      case Failure(e) =>
+        logWarning(s"Could not get collection statistics. Server errmsg: ${e.getMessage}")
+        throw e
+    }
+  }
+}
+
+case object MongoPaginateByCountPartitioner extends MongoPaginateByCountPartitioner

--- a/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoPaginateByCountPartitioner.scala
+++ b/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoPaginateByCountPartitioner.scala
@@ -33,9 +33,9 @@ import com.mongodb.spark.config.ReadConfig
  *
  * $configurationProperties
  *
- *  - [[partitionKeyProperty partitionkey]], the field to partition the collection by. The field should be indexed and contain unique values.
+ *  - [[partitionKeyProperty partitionKey]], the field to partition the collection by. The field should be indexed and contain unique values.
  *     Defaults to `_id`.
- *  - [[numberOfPartitionsProperty numberofpartitions]], the maximum number of partitions to create. Defaults to `64`.
+ *  - [[numberOfPartitionsProperty numberOfPartitions]], the maximum number of partitions to create. Defaults to `64`.
  *
  *
  * '''Note:''' This can be a expensive operation as it creates 1 cursor for every partition.
@@ -69,8 +69,9 @@ class MongoPaginateByCountPartitioner extends MongoPartitioner with MongoPaginat
 
     Try(PartitionerHelper.collStats(connector, readConfig)) match {
       case Success(results) =>
-        val partitionKey = readConfig.partitionerOptions.getOrElse(partitionKeyProperty, DefaultPartitionKey)
-        val maxNumberOfPartitions = readConfig.partitionerOptions.getOrElse(numberOfPartitionsProperty, DefaultNumberOfPartitions).toInt
+        val partitionerOptions = readConfig.partitionerOptions.map(kv => (kv._1.toLowerCase, kv._2))
+        val partitionKey = partitionerOptions.getOrElse(partitionKeyProperty, DefaultPartitionKey)
+        val maxNumberOfPartitions = partitionerOptions.getOrElse(numberOfPartitionsProperty, DefaultNumberOfPartitions).toInt
         val count = results.getNumber("count").longValue()
         val numberOfPartitions = if (count < maxNumberOfPartitions) count else maxNumberOfPartitions
         val numDocumentsPerPartition = math.floor(count / numberOfPartitions).toInt

--- a/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoPaginateBySizePartitioner.scala
+++ b/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoPaginateBySizePartitioner.scala
@@ -33,9 +33,9 @@ import com.mongodb.spark.config.ReadConfig
  *
  * $configurationProperties
  *
- *  - [[partitionKeyProperty partitionkey]], the field to partition the collection by. The field should be indexed and contain unique values.
+ *  - [[partitionKeyProperty partitionKey]], the field to partition the collection by. The field should be indexed and contain unique values.
  *     Defaults to `_id`.
- *  - [[partitionSizeMBProperty partitionsizemb]], the size (in MB) for each partition. Defaults to `64`.
+ *  - [[partitionSizeMBProperty partitionSizeMB]], the size (in MB) for each partition. Defaults to `64`.
  *
  *
  * '''Note:''' This can be a expensive operation as it creates 1 cursor for every estimated `partitionSizeMB`s worth of documents.
@@ -68,8 +68,9 @@ class MongoPaginateBySizePartitioner extends MongoPartitioner with MongoPaginati
 
     Try(PartitionerHelper.collStats(connector, readConfig)) match {
       case Success(results) =>
-        val partitionKey = readConfig.partitionerOptions.getOrElse(partitionKeyProperty, DefaultPartitionKey)
-        val partitionSizeInBytes = readConfig.partitionerOptions.getOrElse(partitionSizeMBProperty, DefaultPartitionSizeMB).toInt * 1024 * 1024
+        val partitionerOptions = readConfig.partitionerOptions.map(kv => (kv._1.toLowerCase, kv._2))
+        val partitionKey = partitionerOptions.getOrElse(partitionKeyProperty, DefaultPartitionKey)
+        val partitionSizeInBytes = partitionerOptions.getOrElse(partitionSizeMBProperty, DefaultPartitionSizeMB).toInt * 1024 * 1024
         val count = results.getNumber("count").longValue()
         val avgObjSizeInBytes = results.getNumber("avgObjSize").longValue()
         val size = results.getNumber("size").longValue()

--- a/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoPaginateBySizePartitioner.scala
+++ b/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoPaginateBySizePartitioner.scala
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2016 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.spark.rdd.partitioner
+
+import scala.util.{Failure, Success, Try}
+
+import org.bson.{BsonDocument, BsonValue}
+import com.mongodb.MongoCommandException
+import com.mongodb.client.MongoCollection
+import com.mongodb.client.model.{Projections, Sorts}
+import com.mongodb.spark.MongoConnector
+import com.mongodb.spark.config.ReadConfig
+
+/**
+ * The pagination by size partitioner.
+ *
+ * Paginates the collection into partitions based on their size.  Uses the `collStats` command and the average document size to
+ * estimate the partition boundaries.
+ *
+ * $configurationProperties
+ *
+ *  - [[partitionKeyProperty partitionkey]], the field to partition the collection by. The field should be indexed and contain unique values.
+ *     Defaults to `_id`.
+ *  - [[partitionSizeMBProperty partitionsizemb]], the size (in MB) for each partition. Defaults to `64`.
+ *
+ *
+ * '''Note:''' This can be a expensive operation as it creates 1 cursor for every estimated `partitionSizeMB`s worth of documents.
+ *
+ * @since 1.0
+ */
+class MongoPaginateBySizePartitioner extends MongoPartitioner with MongoPaginationPartitioner {
+
+  private val DefaultPartitionKey = "_id"
+  private val DefaultPartitionSizeMB = "64"
+
+  /**
+   * The partition key property
+   */
+  val partitionKeyProperty = "partitionKey".toLowerCase()
+
+  /**
+   * The partition size MB property
+   */
+  val partitionSizeMBProperty = "partitionSizeMB".toLowerCase()
+
+  /**
+   * Calculate the Partitions
+   *
+   * @param connector  the MongoConnector
+   * @param readConfig the [[com.mongodb.spark.config.ReadConfig]]
+   * @return the partitions
+   */
+  override def partitions(connector: MongoConnector, readConfig: ReadConfig, pipeline: Array[BsonDocument]): Array[MongoPartition] = {
+
+    Try(PartitionerHelper.collStats(connector, readConfig)) match {
+      case Success(results) =>
+        val partitionKey = readConfig.partitionerOptions.getOrElse(partitionKeyProperty, DefaultPartitionKey)
+        val partitionSizeInBytes = readConfig.partitionerOptions.getOrElse(partitionSizeMBProperty, DefaultPartitionSizeMB).toInt * 1024 * 1024
+        val count = results.getNumber("count").longValue()
+        val avgObjSizeInBytes = results.getNumber("avgObjSize").longValue()
+        val size = results.getNumber("size").longValue()
+        val numberOfPartitions = math.floor(size / partitionSizeInBytes.toFloat).toInt
+        val estNumDocumentsPerPartition: Int = math.floor(partitionSizeInBytes.toFloat / avgObjSizeInBytes).toInt
+
+        val rightHandBoundaries = estNumDocumentsPerPartition >= count match {
+          case true => Seq.empty[BsonValue]
+          case false =>
+            val skipValues = (0 to numberOfPartitions.toInt).map(i => i * estNumDocumentsPerPartition)
+            calculateSkipPartitions(connector, readConfig, partitionKey, count, skipValues)
+        }
+
+        PartitionerHelper.createPartitions(partitionKey, rightHandBoundaries, PartitionerHelper.locations(connector))
+      case Failure(ex: MongoCommandException) if ex.getErrorMessage.endsWith("not found.") =>
+        logInfo(s"Could not find collection (${readConfig.collectionName}), using a single partition")
+        MongoSinglePartitioner.partitions(connector, readConfig, pipeline)
+      case Failure(e) =>
+        logWarning(s"Could not get collection statistics. Server errmsg: ${e.getMessage}")
+        throw e
+    }
+  }
+
+}
+
+case object MongoPaginateBySizePartitioner extends MongoPaginateBySizePartitioner

--- a/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoPaginationPartitioner.scala
+++ b/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoPaginationPartitioner.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2016 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.spark.rdd.partitioner
+
+import org.bson.{BsonDocument, BsonValue}
+import com.mongodb.client.MongoCollection
+import com.mongodb.client.model.{Projections, Sorts}
+import com.mongodb.spark.MongoConnector
+import com.mongodb.spark.config.ReadConfig
+
+private[partitioner] trait MongoPaginationPartitioner {
+
+  private implicit object BsonValueOrdering extends BsonValueOrdering
+
+  def calculateSkipPartitions(connector: MongoConnector, readConfig: ReadConfig, partitionKey: String, count: Long, skipValues: Seq[Int]): Seq[BsonValue] = {
+    skipValues.map(i => connector.withCollectionDo(readConfig, { coll: MongoCollection[BsonDocument] =>
+      i >= count match {
+        case true => None
+        case false =>
+          Option(coll.find()
+            .skip(i)
+            .limit(-1)
+            .projection(Projections.include(partitionKey))
+            .sort(Sorts.ascending(partitionKey))
+            .first())
+            .map(_.get(partitionKey))
+      }
+    })).collect({ case Some(boundary) => boundary }).sorted
+  }
+
+}

--- a/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoPartitioner.scala
+++ b/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoPartitioner.scala
@@ -16,11 +16,18 @@
 
 package com.mongodb.spark.rdd.partitioner
 
+import org.bson.BsonDocument
 import com.mongodb.spark.config.ReadConfig
 import com.mongodb.spark.{Logging, MongoConnector}
 
 /**
  * The MongoPartitioner provides the partitions of a collection
+ *
+ * @define configurationProperties
+ *
+ * == Configuration Properties ==
+ *
+ * The prefix when using `sparkConf` is: `spark.mongodb.input.partitionerOptions` followed by the property name:
  *
  * @since 1.0
  */
@@ -33,6 +40,6 @@ trait MongoPartitioner extends Logging with Serializable {
    * @param readConfig the [[com.mongodb.spark.config.ReadConfig]]
    * @return the partitions
    */
-  def partitions(connector: MongoConnector, readConfig: ReadConfig): Array[MongoPartition]
+  def partitions(connector: MongoConnector, readConfig: ReadConfig, pipeline: Array[BsonDocument]): Array[MongoPartition]
 
 }

--- a/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoSamplePartitioner.scala
+++ b/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoSamplePartitioner.scala
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2016 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.spark.rdd.partitioner
+
+import java.util
+
+import scala.collection.JavaConverters._
+import scala.util.{Failure, Success, Try}
+
+import org.bson.{BsonDocument, BsonValue}
+import com.mongodb.MongoCommandException
+import com.mongodb.client.MongoCollection
+import com.mongodb.client.model.{Aggregates, Projections, Sorts}
+import com.mongodb.spark.MongoConnector
+import com.mongodb.spark.config.ReadConfig
+
+/**
+ * The Sample Partitioner.
+ *
+ * Uses the average document size and random sampling of the collection to determine suitable partitions for the collection.
+ *
+ * $configurationProperties
+ *
+ *  - [[partitionKeyProperty partitionkey]], the field to partition the collection by. The field should be indexed and contain unique values.
+ *     Defaults to `_id`.
+ *  - [[partitionSizeMBProperty partitionsizemb]], the size (in MB) for each partition. Defaults to `64`.
+ *  - [[samplesPerPartitionProperty samplesperpartition]], the number of samples for each partition. Defaults to `10`.
+ *
+ * *Note:* Requires MongoDB 3.2+
+ *
+ * @since 1.0
+ */
+class MongoSamplePartitioner extends MongoPartitioner {
+  private val DefaultPartitionKey = "_id"
+  private val DefaultPartitionSizeMB = "64"
+  private val DefaultSamplesPerPartition = "10"
+
+  /**
+   * The partition key property
+   */
+  val partitionKeyProperty = "partitionKey".toLowerCase()
+
+  /**
+   * The partition size MB property
+   */
+  val partitionSizeMBProperty = "partitionSizeMB".toLowerCase()
+
+  /**
+   * The number of samples for each partition
+   */
+  val samplesPerPartitionProperty = "samplesPerPartition".toLowerCase()
+
+  /**
+   * Calculate the Partitions
+   *
+   * @param connector  the MongoConnector
+   * @param readConfig the [[com.mongodb.spark.config.ReadConfig]]
+   * @return the partitions
+   */
+  override def partitions(connector: MongoConnector, readConfig: ReadConfig, pipeline: Array[BsonDocument]): Array[MongoPartition] = {
+
+    Try(PartitionerHelper.collStats(connector, readConfig)) match {
+      case Success(results) =>
+        val partitionKey = readConfig.partitionerOptions.getOrElse(partitionKeyProperty, DefaultPartitionKey)
+        val partitionSizeInBytes = readConfig.partitionerOptions.getOrElse(partitionSizeMBProperty, DefaultPartitionSizeMB).toInt * 1024 * 1024
+        val samplesPerPartition = readConfig.partitionerOptions.getOrElse(samplesPerPartitionProperty, DefaultSamplesPerPartition).toInt
+
+        val count = results.getNumber("count").longValue()
+        val avgObjSizeInBytes = results.getNumber("avgObjSize").longValue()
+        val estNumDocumentsPerPartition: Int = math.floor(partitionSizeInBytes.toFloat / avgObjSizeInBytes).toInt
+        val numberOfSamples = math.floor(samplesPerPartition * count / estNumDocumentsPerPartition.toFloat).toInt
+
+        val rightHandBoundaries = estNumDocumentsPerPartition >= count match {
+          case true => Seq.empty[BsonValue]
+          case false =>
+            val samples = connector.withCollectionDo(readConfig, {
+              coll: MongoCollection[BsonDocument] =>
+                coll.aggregate(List(
+                  Aggregates.sample(numberOfSamples),
+                  Aggregates.project(Projections.include(partitionKey)),
+                  Aggregates.sort(Sorts.ascending(partitionKey))
+                ).asJava).into(new util.ArrayList[BsonDocument]()).asScala
+            })
+            samples.zipWithIndex.collect { case (field, i) if i % samplesPerPartition == 0 => field.get("_id") }
+        }
+
+        PartitionerHelper.createPartitions(partitionKey, rightHandBoundaries, PartitionerHelper.locations(connector))
+      case Failure(ex: MongoCommandException) if ex.getErrorMessage.endsWith("not found.") =>
+        logInfo(s"Could not find collection (${readConfig.collectionName}), using a single partition")
+        MongoSinglePartitioner.partitions(connector, readConfig, pipeline)
+      case Failure(e) =>
+        logWarning(s"Could not get collection statistics. Server errmsg: ${e.getMessage}")
+        throw e
+    }
+  }
+}
+
+case object MongoSamplePartitioner extends MongoSamplePartitioner

--- a/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoSamplePartitioner.scala
+++ b/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoSamplePartitioner.scala
@@ -35,10 +35,10 @@ import com.mongodb.spark.config.ReadConfig
  *
  * $configurationProperties
  *
- *  - [[partitionKeyProperty partitionkey]], the field to partition the collection by. The field should be indexed and contain unique values.
+ *  - [[partitionKeyProperty partitionKey]], the field to partition the collection by. The field should be indexed and contain unique values.
  *     Defaults to `_id`.
- *  - [[partitionSizeMBProperty partitionsizemb]], the size (in MB) for each partition. Defaults to `64`.
- *  - [[samplesPerPartitionProperty samplesperpartition]], the number of samples for each partition. Defaults to `10`.
+ *  - [[partitionSizeMBProperty partitionSizeMB]], the size (in MB) for each partition. Defaults to `64`.
+ *  - [[samplesPerPartitionProperty samplesPerPartition]], the number of samples for each partition. Defaults to `10`.
  *
  * *Note:* Requires MongoDB 3.2+
  *
@@ -75,9 +75,10 @@ class MongoSamplePartitioner extends MongoPartitioner {
 
     Try(PartitionerHelper.collStats(connector, readConfig)) match {
       case Success(results) =>
-        val partitionKey = readConfig.partitionerOptions.getOrElse(partitionKeyProperty, DefaultPartitionKey)
-        val partitionSizeInBytes = readConfig.partitionerOptions.getOrElse(partitionSizeMBProperty, DefaultPartitionSizeMB).toInt * 1024 * 1024
-        val samplesPerPartition = readConfig.partitionerOptions.getOrElse(samplesPerPartitionProperty, DefaultSamplesPerPartition).toInt
+        val partitionerOptions = readConfig.partitionerOptions.map(kv => (kv._1.toLowerCase, kv._2))
+        val partitionKey = partitionerOptions.getOrElse(partitionKeyProperty, DefaultPartitionKey)
+        val partitionSizeInBytes = partitionerOptions.getOrElse(partitionSizeMBProperty, DefaultPartitionSizeMB).toInt * 1024 * 1024
+        val samplesPerPartition = partitionerOptions.getOrElse(samplesPerPartitionProperty, DefaultSamplesPerPartition).toInt
 
         val count = results.getNumber("count").longValue()
         val avgObjSizeInBytes = results.getNumber("avgObjSize").longValue()

--- a/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoShardedPartitioner.scala
+++ b/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoShardedPartitioner.scala
@@ -32,14 +32,26 @@ import com.mongodb.spark.config.ReadConfig
  *
  * Partitions collections by shard and chunk.
  *
+ *  $configurationProperties
+ *
+ *  - [[MongoShardedPartitioner#shardKeyProperty shardkey]], the shardKey for the collection. Defaults to `_id`.
+ *
  * @since 1.0
  */
-case object MongoShardedPartitioner extends MongoPartitioner {
+class MongoShardedPartitioner extends MongoPartitioner {
 
-  override def partitions(connector: MongoConnector, readConfig: ReadConfig): Array[MongoPartition] = {
+  private val DefaultShardKey = "_id"
+
+  /**
+   * The shardKey property
+   */
+  val shardKeyProperty = "shardKey".toLowerCase()
+
+  override def partitions(connector: MongoConnector, readConfig: ReadConfig, pipeline: Array[BsonDocument]): Array[MongoPartition] = {
     val ns: String = s"${readConfig.databaseName}.${readConfig.collectionName}"
     logDebug(s"Getting split bounds for a sharded collection: $ns")
 
+    val shardKey = readConfig.partitionerOptions.getOrElse(shardKeyProperty, DefaultShardKey)
     val chunks: Seq[BsonDocument] = connector.withCollectionDo(
       ReadConfig("config", "chunks"), { collection: MongoCollection[BsonDocument] =>
         collection.find(Filters.eq("ns", ns)).projection(Projections.include("min", "max", "shard"))
@@ -55,19 +67,19 @@ case object MongoShardedPartitioner extends MongoPartitioner {
         )
         MongoSinglePartitioner.partitions(connector, readConfig)
       case false =>
-        generatePartitions(chunks, readConfig.splitKey, mapShards(connector))
+        generatePartitions(chunks, shardKey, mapShards(connector))
     }
   }
 
-  private[partitioner] def generatePartitions(chunks: Seq[BsonDocument], splitKey: String, shardsMap: Map[String, Seq[String]]): Array[MongoPartition] = {
+  private[partitioner] def generatePartitions(chunks: Seq[BsonDocument], shardKey: String, shardsMap: Map[String, Seq[String]]): Array[MongoPartition] = {
     chunks.zipWithIndex.map({
       case (chunk: BsonDocument, i: Int) =>
         MongoPartition(
           i,
           PartitionerHelper.createBoundaryQuery(
-            splitKey,
-            chunk.getDocument("min").get(splitKey),
-            chunk.getDocument("max").get(splitKey)
+            shardKey,
+            chunk.getDocument("min").get(shardKey),
+            chunk.getDocument("max").get(shardKey)
           ),
           shardsMap.getOrElse(chunk.getString("shard").getValue, Nil)
         )
@@ -86,3 +98,5 @@ case object MongoShardedPartitioner extends MongoPartitioner {
   private[partitioner] def getHosts(hosts: String): Seq[String] = hosts.split(",").toSeq.map(getHost).distinct
   private[partitioner] def getHost(hostAndPort: String): String = new ServerAddress(hostAndPort.split("/").reverse.head).getHost
 }
+
+case object MongoShardedPartitioner extends MongoShardedPartitioner

--- a/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoShardedPartitioner.scala
+++ b/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoShardedPartitioner.scala
@@ -34,7 +34,7 @@ import com.mongodb.spark.config.ReadConfig
  *
  *  $configurationProperties
  *
- *  - [[MongoShardedPartitioner#shardKeyProperty shardkey]], the shardKey for the collection. Defaults to `_id`.
+ *  - [[MongoShardedPartitioner#shardKeyProperty shardKey]], the shardKey for the collection. Defaults to `_id`.
  *
  * @since 1.0
  */
@@ -50,8 +50,8 @@ class MongoShardedPartitioner extends MongoPartitioner {
   override def partitions(connector: MongoConnector, readConfig: ReadConfig, pipeline: Array[BsonDocument]): Array[MongoPartition] = {
     val ns: String = s"${readConfig.databaseName}.${readConfig.collectionName}"
     logDebug(s"Getting split bounds for a sharded collection: $ns")
-
-    val shardKey = readConfig.partitionerOptions.getOrElse(shardKeyProperty, DefaultShardKey)
+    val partitionerOptions = readConfig.partitionerOptions.map(kv => (kv._1.toLowerCase, kv._2))
+    val shardKey = partitionerOptions.getOrElse(shardKeyProperty, DefaultShardKey)
     val chunks: Seq[BsonDocument] = connector.withCollectionDo(
       ReadConfig("config", "chunks"), { collection: MongoCollection[BsonDocument] =>
         collection.find(Filters.eq("ns", ns)).projection(Projections.include("min", "max", "shard"))

--- a/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoSinglePartitioner.scala
+++ b/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoSinglePartitioner.scala
@@ -16,7 +16,7 @@
 
 package com.mongodb.spark.rdd.partitioner
 
-import org.bson.BsonDocument
+import org.bson.{BsonDocument, BsonValue}
 import com.mongodb.spark.MongoConnector
 import com.mongodb.spark.config.ReadConfig
 
@@ -29,7 +29,13 @@ import com.mongodb.spark.config.ReadConfig
  *
  * @since 1.0
  */
-case object MongoSinglePartitioner extends MongoPartitioner {
-  override def partitions(connector: MongoConnector, readConfig: ReadConfig): Array[MongoPartition] =
-    Array(MongoPartition(0, new BsonDocument()))
+class MongoSinglePartitioner extends MongoPartitioner {
+
+  override def partitions(connector: MongoConnector, readConfig: ReadConfig,
+                          pipeline: Array[BsonDocument] = Array.empty[BsonDocument]): Array[MongoPartition] = {
+    PartitionerHelper.createPartitions("_id", Seq.empty[BsonValue], PartitionerHelper.locations(connector))
+  }
 }
+
+case object MongoSinglePartitioner extends MongoSinglePartitioner
+

--- a/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoSplitVectorPartitioner.scala
+++ b/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoSplitVectorPartitioner.scala
@@ -22,7 +22,7 @@ import scala.collection.JavaConverters._
 import scala.util.{Failure, Success, Try}
 
 import org.bson._
-import com.mongodb.MongoNotPrimaryException
+import com.mongodb.{MongoCommandException, MongoNotPrimaryException}
 import com.mongodb.spark.MongoConnector
 import com.mongodb.spark.config.ReadConfig
 import com.mongodb.spark.exceptions.MongoSplitException
@@ -31,60 +31,73 @@ import com.mongodb.spark.exceptions.MongoSplitException
  * The SplitVector Partitioner.
  *
  * Uses the `SplitVector` command on the primary node to generate partitions for a collection.
+ * Requires `ClusterManager` privilege.
+ *
+ *  $configurationProperties
+ *
+ *  - [[partitionKeyProperty partitionkey]], the field to partition the collection by. The field should be indexed and contain unique values.
+ *     Defaults to `_id`.
+ *  - [[partitionSizeMBProperty partitionsizemb]], the size (in MB) for each partition. Defaults to `64`.
  *
  * @since 1.0
  */
-case object MongoSplitVectorPartitioner extends MongoPartitioner {
+class MongoSplitVectorPartitioner extends MongoPartitioner {
+  private val DefaultPartitionKey = "_id"
+  private val DefaultPartitionSizeMB = "64"
 
-  override def partitions(connector: MongoConnector, readConfig: ReadConfig): Array[MongoPartition] = {
+  /**
+   * The partition key property
+   */
+  val partitionKeyProperty = "partitionKey".toLowerCase()
+
+  /**
+   * The partition size MB property
+   */
+  val partitionSizeMBProperty = "partitionSizeMB".toLowerCase()
+
+  override def partitions(connector: MongoConnector, readConfig: ReadConfig, pipeline: Array[BsonDocument]): Array[MongoPartition] = {
     val ns: String = s"${readConfig.databaseName}.${readConfig.collectionName}"
     logDebug(s"Getting split bounds for a non-sharded collection: $ns")
 
-    val keyPattern: BsonDocument = new BsonDocument(readConfig.splitKey, new BsonInt32(1))
+    val partitionKey = readConfig.partitionerOptions.getOrElse(partitionKeyProperty, DefaultPartitionKey)
+    val partitionSize = readConfig.partitionerOptions.getOrElse(partitionSizeMBProperty, DefaultPartitionSizeMB).toInt
+
+    val keyPattern: BsonDocument = new BsonDocument(partitionKey, new BsonInt32(1))
     val splitVectorCommand: BsonDocument = new BsonDocument("splitVector", new BsonString(ns))
       .append("keyPattern", keyPattern)
-      .append("maxChunkSize", new BsonInt32(readConfig.maxChunkSize))
+      .append("maxChunkSize", new BsonInt32(partitionSize))
 
     connector.withDatabaseDo(readConfig, { db =>
       Try(db.runCommand(splitVectorCommand, classOf[BsonDocument])) match {
         case Success(result: BsonDocument) =>
           val locations: Seq[String] = connector.withMongoClientDo(mongoClient => mongoClient.getAllAddress.asScala.map(_.getHost).distinct)
-          createPartitions(readConfig.splitKey, result, locations)
+          createPartitions(partitionKey, result, locations)
         case Failure(e: MongoNotPrimaryException) =>
-          logWarning(s"Splitting failed: '${e.getMessage}'. Continuing with a single partition.")
-          MongoSinglePartitioner.partitions(connector, readConfig)
+          logWarning("The `SplitVector` command must be run on the primary node")
+          throw e
+        case Failure(ex: MongoCommandException) if ex.getErrorMessage.contains("ns not found") =>
+          logInfo(s"Could not find collection (${readConfig.collectionName}), using a single partition")
+          MongoSinglePartitioner.partitions(connector, readConfig, pipeline)
         case Failure(t: Throwable) => throw t
       }
     })
   }
 
-  private def createPartitions(splitKey: String, result: BsonDocument, locations: Seq[String]): Array[MongoPartition] = {
+  private def createPartitions(partitionKey: String, result: BsonDocument, locations: Seq[String]): Array[MongoPartition] = {
     result.getDouble("ok").getValue match {
       case 1.0 =>
-        val minBounds = new BsonDocument(splitKey, new BsonMinKey())
-        val splitKeys: Seq[BsonDocument] = result.get("splitKeys").asInstanceOf[util.List[BsonDocument]].asScala
-        val maxBounds = new BsonDocument(splitKey, new BsonMaxKey())
-        val minToMaxSplitKeys: Seq[BsonDocument] = minBounds +: splitKeys :+ maxBounds
-        if (splitKeys.isEmpty) {
+        val rightHandPartitionBoundaries = result.get("splitKeys").asInstanceOf[util.List[BsonDocument]].asScala.map(_.get(partitionKey))
+        val partitions = PartitionerHelper.createPartitions(partitionKey, rightHandPartitionBoundaries, locations)
+        if (partitions.length == 1) {
           logInfo(
             """No splitKeys were calculated by the splitVector command, proceeding with a single partition.
-              |If this is undesirable try lowering 'maxChunkSize' to produce more partitions.""".stripMargin.replaceAll("\n", " ")
+              |If this is undesirable try lowering 'partitionSizeMB' property to produce more partitions.""".stripMargin.replaceAll("\n", " ")
           )
         }
-        val splitKeyPairs: Seq[(BsonDocument, BsonDocument)] = minToMaxSplitKeys zip minToMaxSplitKeys.tail
-        splitKeyPairs.zipWithIndex.map({
-          case ((minKey: BsonDocument, maxKey: BsonDocument), i: Int) =>
-            MongoPartition(
-              i,
-              PartitionerHelper.createBoundaryQuery(
-                splitKey,
-                minKey.get(splitKey),
-                maxKey.get(splitKey)
-              ),
-              locations
-            )
-        }).toArray
+        partitions
       case _ => throw new MongoSplitException(s"""Could not calculate standalone splits. Server errmsg: ${result.get("errmsg")}""")
     }
   }
 }
+
+case object MongoSplitVectorPartitioner extends MongoSplitVectorPartitioner

--- a/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoSplitVectorPartitioner.scala
+++ b/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoSplitVectorPartitioner.scala
@@ -35,9 +35,9 @@ import com.mongodb.spark.exceptions.MongoSplitException
  *
  *  $configurationProperties
  *
- *  - [[partitionKeyProperty partitionkey]], the field to partition the collection by. The field should be indexed and contain unique values.
+ *  - [[partitionKeyProperty partitionKey]], the field to partition the collection by. The field should be indexed and contain unique values.
  *     Defaults to `_id`.
- *  - [[partitionSizeMBProperty partitionsizemb]], the size (in MB) for each partition. Defaults to `64`.
+ *  - [[partitionSizeMBProperty partitionSizeMB]], the size (in MB) for each partition. Defaults to `64`.
  *
  * @since 1.0
  */
@@ -59,8 +59,9 @@ class MongoSplitVectorPartitioner extends MongoPartitioner {
     val ns: String = s"${readConfig.databaseName}.${readConfig.collectionName}"
     logDebug(s"Getting split bounds for a non-sharded collection: $ns")
 
-    val partitionKey = readConfig.partitionerOptions.getOrElse(partitionKeyProperty, DefaultPartitionKey)
-    val partitionSize = readConfig.partitionerOptions.getOrElse(partitionSizeMBProperty, DefaultPartitionSizeMB).toInt
+    val partitionerOptions = readConfig.partitionerOptions.map(kv => (kv._1.toLowerCase, kv._2))
+    val partitionKey = partitionerOptions.getOrElse(partitionKeyProperty, DefaultPartitionKey)
+    val partitionSize = partitionerOptions.getOrElse(partitionSizeMBProperty, DefaultPartitionSizeMB).toInt
 
     val keyPattern: BsonDocument = new BsonDocument(partitionKey, new BsonInt32(1))
     val splitVectorCommand: BsonDocument = new BsonDocument("splitVector", new BsonString(ns))

--- a/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoSplitVectorPartitioner.scala
+++ b/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoSplitVectorPartitioner.scala
@@ -25,7 +25,7 @@ import org.bson._
 import com.mongodb.{MongoCommandException, MongoNotPrimaryException}
 import com.mongodb.spark.MongoConnector
 import com.mongodb.spark.config.ReadConfig
-import com.mongodb.spark.exceptions.MongoSplitException
+import com.mongodb.spark.exceptions.MongoPartitionerException
 
 /**
  * The SplitVector Partitioner.
@@ -96,7 +96,7 @@ class MongoSplitVectorPartitioner extends MongoPartitioner {
           )
         }
         partitions
-      case _ => throw new MongoSplitException(s"""Could not calculate standalone splits. Server errmsg: ${result.get("errmsg")}""")
+      case _ => throw new MongoPartitionerException(s"""Could not calculate standalone splits. Server errmsg: ${result.get("errmsg")}""")
     }
   }
 }

--- a/src/main/scala/com/mongodb/spark/rdd/partitioner/PartitionerHelper.scala
+++ b/src/main/scala/com/mongodb/spark/rdd/partitioner/PartitionerHelper.scala
@@ -16,9 +16,13 @@
 
 package com.mongodb.spark.rdd.partitioner
 
-import org.bson.{BsonDocument, BsonValue}
+import scala.collection.JavaConverters._
 
-private[partitioner] object PartitionerHelper {
+import org.bson._
+import com.mongodb.spark.MongoConnector
+import com.mongodb.spark.config.ReadConfig
+
+object PartitionerHelper {
 
   /**
    * Creates the upper and lower boundary query for the given key
@@ -30,5 +34,42 @@ private[partitioner] object PartitionerHelper {
    */
   def createBoundaryQuery(key: String, lower: BsonValue, upper: BsonValue): BsonDocument =
     new BsonDocument(key, new BsonDocument("$gte", lower).append("$lt", upper))
+
+  /**
+   * Creates partitions using a single Seq of documents representing the right handside of partitions
+   *
+   * @param partitionKey the key representing the partition most likely the `_id`.
+   * @param partitions the documents representing a split
+   * @param locations the optional server hostnames for the data
+   * @return
+   */
+  def createPartitions(partitionKey: String, partitions: Seq[BsonValue], locations: Seq[String] = Nil): Array[MongoPartition] = {
+    val minToMaxSplitKeys: Seq[BsonValue] = new BsonMinKey() +: partitions :+ new BsonMaxKey()
+    val partitionPairs: Seq[(BsonValue, BsonValue)] = minToMaxSplitKeys zip minToMaxSplitKeys.tail
+    partitionPairs.zipWithIndex.map({
+      case ((min: BsonValue, max: BsonValue), i: Int) => MongoPartition(i, createBoundaryQuery(partitionKey, min, max), locations)
+    }).toArray
+  }
+
+  /**
+   * Get the locations of the Mongo hosts
+   *
+   * @param connector the MongoConnector
+   * @return the locations
+   */
+  def locations(connector: MongoConnector): Seq[String] =
+    connector.withMongoClientDo(mongoClient => mongoClient.getAllAddress.asScala.map(_.getHost).distinct)
+
+  /**
+   * Runs the `collStats` command and returns the results
+   *
+   * @param connector the MongoConnector
+   * @param readConfig the readConfig
+   * @return the collStats result
+   */
+  def collStats(connector: MongoConnector, readConfig: ReadConfig): BsonDocument = {
+    val collStatsCommand: BsonDocument = new BsonDocument("collStats", new BsonString(readConfig.collectionName))
+    connector.withDatabaseDo(readConfig, { db => db.runCommand(collStatsCommand, readConfig.readPreference, classOf[BsonDocument]) })
+  }
 
 }

--- a/src/test/java/com/mongodb/spark/JavaHalfwayPartitioner.java
+++ b/src/test/java/com/mongodb/spark/JavaHalfwayPartitioner.java
@@ -26,8 +26,9 @@ import org.bson.BsonDocument;
 import org.bson.BsonValue;
 
 public final class JavaHalfwayPartitioner implements MongoPartitioner {
+
     @Override
-    public MongoPartition[] partitions(final MongoConnector connector, final ReadConfig readConfig) {
+    public MongoPartition[] partitions(final MongoConnector connector, final ReadConfig readConfig, final BsonDocument[] pipeline) {
         BsonValue midId = connector.withCollectionDo(readConfig, BsonDocument.class, new Function<MongoCollection<BsonDocument>,
                 BsonValue>() {
             @Override
@@ -39,4 +40,5 @@ public final class JavaHalfwayPartitioner implements MongoPartitioner {
         return new MongoPartition[]{ MongoPartition.create(0, new BsonDocument("_id", new BsonDocument("$lt", midId))),
                                      MongoPartition.create(1, new BsonDocument("_id", new BsonDocument("$gte", midId)))};
     }
+
 }

--- a/src/test/java/com/mongodb/spark/MongoSparkTest.java
+++ b/src/test/java/com/mongodb/spark/MongoSparkTest.java
@@ -234,8 +234,11 @@ public final class MongoSparkTest extends JavaRequiresMongoDB {
         MongoSpark.save(jsc.parallelize(documents));
 
         // when
-        JavaMongoRDD<Document> mongoRDD =
-                MongoSpark.builder().javaSparkContext(jsc).partitioner(new JavaHalfwayPartitioner()).build().toJavaRDD();
+        JavaMongoRDD<Document> mongoRDD = MongoSpark.builder()
+                .javaSparkContext(jsc)
+                .option("partitioner", "com.mongodb.spark.JavaHalfwayPartitioner")
+                .build()
+                .toJavaRDD();
 
         // then - default values
         assertEquals(mongoRDD.getNumPartitions(), 2);

--- a/src/test/java/com/mongodb/spark/NoSparkConfTest.java
+++ b/src/test/java/com/mongodb/spark/NoSparkConfTest.java
@@ -85,9 +85,10 @@ public final class NoSparkConfTest extends JavaRequiresMongoDB {
 
     private Map<String, String> getOptions() {
         Map<String, String> options = new HashMap<String, String>();
-        options.put("uri",  getMongoClientURI());
-        options.put("database",  getDatabaseName());
-        options.put("collection",  getCollectionName());
+        options.put("uri", getMongoClientURI());
+        options.put("database", getDatabaseName());
+        options.put("collection", getCollectionName());
+        options.put("partitioner", "TestPartitioner$");
         return options;
     }
 

--- a/src/test/java/com/mongodb/spark/config/ReadConfigTest.java
+++ b/src/test/java/com/mongodb/spark/config/ReadConfigTest.java
@@ -33,11 +33,19 @@ public final class ReadConfigTest extends JavaRequiresMongoDB {
 
     @Test
     public void shouldBeCreatableFromTheSparkConf() {
-        ReadConfig readConfig = ReadConfig.create(getSparkConf());
-        ReadConfig expectedReadConfig = ReadConfig.create(getDatabaseName(), getCollectionName(), getMongoClientURI(), 1000, 64, "_id",
-                15, ReadPreference.primary(), ReadConcern.DEFAULT);
+        ReadConfig readConfig = ReadConfig.create(getSparkConf().remove("spark.mongodb.input.partitioner"));
+        ReadConfig expectedReadConfig = ReadConfig.create(getDatabaseName(), getCollectionName(), getMongoClientURI(), 1000,
+                "DefaultMongoPartitioner$", new HashMap<String, String>(), 15, ReadPreference.primary(), ReadConcern.DEFAULT);
 
-        assertEquals(readConfig, expectedReadConfig);
+        assertEquals(readConfig.databaseName(), expectedReadConfig.databaseName());
+        assertEquals(readConfig.collectionName(), expectedReadConfig.collectionName());
+        assertEquals(readConfig.connectionString(), expectedReadConfig.connectionString());
+        assertEquals(readConfig.sampleSize(), expectedReadConfig.sampleSize());
+        assertEquals(readConfig.partitioner(), expectedReadConfig.partitioner());
+        assertEquals(readConfig.partitionerOptions(), expectedReadConfig.partitionerOptions());
+        assertEquals(readConfig.localThreshold(), expectedReadConfig.localThreshold());
+        assertEquals(readConfig.readPreferenceConfig(), expectedReadConfig.readPreferenceConfig());
+        assertEquals(readConfig.readConcernConfig(), expectedReadConfig.readConcernConfig());
     }
 
     @Test
@@ -46,19 +54,30 @@ public final class ReadConfigTest extends JavaRequiresMongoDB {
         options.put(ReadConfig.databaseNameProperty(), "db");
         options.put(ReadConfig.collectionNameProperty(), "collection");
         options.put(ReadConfig.sampleSizeProperty(), "500");
-        options.put(ReadConfig.maxChunkSizeProperty(), "99");
-        options.put(ReadConfig.splitKeyProperty(), "ID");
+        options.put(ReadConfig.partitionerProperty(), "MongoSamplePartitioner$");
+        options.put(ReadConfig.partitionerOptionsProperty() + ".partitionSizeMB", "10");
         options.put(ReadConfig.localThresholdProperty(), "0");
         options.put(ReadConfig.readPreferenceNameProperty(), "secondaryPreferred");
         options.put(ReadConfig.readPreferenceTagSetsProperty(), "[{dc: \"east\", use: \"production\"},{}]");
         options.put(ReadConfig.readConcernLevelProperty(), "majority");
 
         ReadConfig readConfig = ReadConfig.create(options);
-        ReadConfig expectedReadConfig = ReadConfig.create("db", "collection", null, 500, 99, "ID", 0,
+        HashMap<String, String> partitionerOptions = new HashMap<String, String>();
+        partitionerOptions.put(ReadConfig.partitionerOptionsProperty() + ".partitionSizeMB", "10");
+        ReadConfig expectedReadConfig = ReadConfig.create("db", "collection", null, 500, "MongoSamplePartitioner$",
+                partitionerOptions, 0,
                 ReadPreference.secondaryPreferred(asList(new TagSet(asList(new Tag("dc", "east"), new Tag("use", "production"))), new TagSet())),
                 ReadConcern.MAJORITY);
 
-        assertEquals(readConfig, expectedReadConfig);
+        assertEquals(readConfig.databaseName(), expectedReadConfig.databaseName());
+        assertEquals(readConfig.collectionName(), expectedReadConfig.collectionName());
+        assertEquals(readConfig.connectionString(), expectedReadConfig.connectionString());
+        assertEquals(readConfig.sampleSize(), expectedReadConfig.sampleSize());
+        assertEquals(readConfig.partitioner(), expectedReadConfig.partitioner());
+        assertEquals(readConfig.partitionerOptions(), expectedReadConfig.partitionerOptions());
+        assertEquals(readConfig.localThreshold(), expectedReadConfig.localThreshold());
+        assertEquals(readConfig.readPreferenceConfig(), expectedReadConfig.readPreferenceConfig());
+        assertEquals(readConfig.readConcernConfig(), expectedReadConfig.readConcernConfig());
     }
 
     @Test
@@ -69,10 +88,19 @@ public final class ReadConfigTest extends JavaRequiresMongoDB {
         options.put(ReadConfig.readPreferenceNameProperty(), "secondaryPreferred");
         options.put(ReadConfig.readConcernLevelProperty(), "majority");
 
-        ReadConfig readConfig = ReadConfig.create(options, ReadConfig.create(getSparkConf()));
-        ReadConfig expectedReadConfig = ReadConfig.create("db", "collection", getMongoClientURI(), 1000, 64, "_id", 15,
-                ReadPreference.secondaryPreferred(), ReadConcern.MAJORITY);
+        ReadConfig readConfig = ReadConfig.create(options, ReadConfig.create(getSparkConf().remove("spark.mongodb.input.partitioner")));
+        ReadConfig expectedReadConfig = ReadConfig.create("db", "collection", getMongoClientURI(), 1000,
+                "DefaultMongoPartitioner$", new HashMap<String, String>(), 15, ReadPreference.secondaryPreferred(),
+                ReadConcern.MAJORITY);
 
-        assertEquals(readConfig, expectedReadConfig);
+        assertEquals(readConfig.databaseName(), expectedReadConfig.databaseName());
+        assertEquals(readConfig.collectionName(), expectedReadConfig.collectionName());
+        assertEquals(readConfig.connectionString(), expectedReadConfig.connectionString());
+        assertEquals(readConfig.sampleSize(), expectedReadConfig.sampleSize());
+        assertEquals(readConfig.partitioner(), expectedReadConfig.partitioner());
+        assertEquals(readConfig.partitionerOptions(), expectedReadConfig.partitionerOptions());
+        assertEquals(readConfig.localThreshold(), expectedReadConfig.localThreshold());
+        assertEquals(readConfig.readPreferenceConfig(), expectedReadConfig.readPreferenceConfig());
+        assertEquals(readConfig.readConcernConfig(), expectedReadConfig.readConcernConfig());
     }
 }

--- a/src/test/scala/com/mongodb/spark/HalfwayPartitioner.scala
+++ b/src/test/scala/com/mongodb/spark/HalfwayPartitioner.scala
@@ -22,8 +22,8 @@ import com.mongodb.client.model.Projections
 import com.mongodb.spark.config.ReadConfig
 import com.mongodb.spark.rdd.partitioner.{MongoPartition, MongoPartitioner}
 
-object HalfwayPartitioner extends MongoPartitioner {
-  override def partitions(connector: MongoConnector, readConfig: ReadConfig): Array[MongoPartition] = {
+class HalfwayPartitioner extends MongoPartitioner {
+  override def partitions(connector: MongoConnector, readConfig: ReadConfig, pipeline: Array[BsonDocument]): Array[MongoPartition] = {
     val midId = connector.withCollectionDo(readConfig, { collection: MongoCollection[BsonDocument] =>
       @transient val midPoint = collection.count() / 2
       collection.find().skip(midPoint.toInt).limit(1).projection(Projections.include("_id")).first().get("_id")
@@ -34,3 +34,5 @@ object HalfwayPartitioner extends MongoPartitioner {
     )
   }
 }
+
+case object HalfwayPartitioner extends HalfwayPartitioner

--- a/src/test/scala/com/mongodb/spark/MongoRDDSpec.scala
+++ b/src/test/scala/com/mongodb/spark/MongoRDDSpec.scala
@@ -128,7 +128,23 @@ class MongoRDDSpec extends RequiresMongoDB {
   it should "be easy to use a custom partitioner" in withSparkContext() { sc =>
     sc.parallelize((1 to 100).map(i => Document.parse(s"{number: $i}"))).saveToMongoDB()
 
-    val mongoRDD: MongoRDD[Document] = MongoSpark.builder().sparkContext(sc).partitioner(HalfwayPartitioner).build().toRDD()
+    val mongoRDD: MongoRDD[Document] = MongoSpark.builder()
+      .sparkContext(sc)
+      .option("partitioner", "com.mongodb.spark.HalfwayPartitioner")
+      .build()
+      .toRDD()
+    mongoRDD.getNumPartitions should equal(2)
+    mongoRDD.mapPartitions(iter => Array(iter.size).iterator).collect() should equal(Array(50, 50)) // scalastyle:ignore
+  }
+
+  it should "be easy to use a custom partitioner that is an object " in withSparkContext() { sc =>
+    sc.parallelize((1 to 100).map(i => Document.parse(s"{number: $i}"))).saveToMongoDB()
+
+    val mongoRDD: MongoRDD[Document] = MongoSpark.builder()
+      .sparkContext(sc)
+      .option("partitioner", "com.mongodb.spark.HalfwayPartitioner$")
+      .build()
+      .toRDD()
     mongoRDD.getNumPartitions should equal(2)
     mongoRDD.mapPartitions(iter => Array(iter.size).iterator).collect() should equal(Array(50, 50)) // scalastyle:ignore
   }

--- a/src/test/scala/com/mongodb/spark/SparkConfOverrideSpec.scala
+++ b/src/test/scala/com/mongodb/spark/SparkConfOverrideSpec.scala
@@ -23,9 +23,9 @@ import org.bson.Document
 import com.mongodb.spark.config.{ReadConfig, WriteConfig}
 import com.mongodb.spark.sql.{Character, _}
 
-class NoSparkConfSpec extends RequiresMongoDB {
+class SparkConfOverrideSpec extends RequiresMongoDB {
 
-  "MongoRDD" should "be able to accept just Read / Write Configs" in {
+  "MongoRDD" should "be able to override partial configs with Read / Write Configs" in {
     val writeConfig = WriteConfig(Map("uri" -> mongoClientURI, "database" -> databaseName, "collection" -> collectionName))
     val readConfig = ReadConfig(Map("uri" -> mongoClientURI, "database" -> databaseName, "collection" -> collectionName,
       "partitioner" -> "TestPartitioner$"))
@@ -38,7 +38,7 @@ class NoSparkConfSpec extends RequiresMongoDB {
     rdd.map(_.getInteger("test")).collect().toList should equal((1 to 10).toList)
   }
 
-  "DataFrame Readers and Writers" should "be able to accept just options" in {
+  "DataFrame Readers and Writers" should "be able to able to override partial configs with options" in {
     val characters = Seq(Character("Gandalf", 1000), Character("Bilbo Baggins", 50)) //scalastyle:ignore
 
     val sqlContext = SQLContext.getOrCreate(sc)
@@ -60,7 +60,10 @@ class NoSparkConfSpec extends RequiresMongoDB {
     ds.collect().toList should equal(characters)
   }
 
-  val sc: SparkContext = new SparkContext(new SparkConf().setMaster("local").setAppName("MongoSparkConnector"))
+  val conf: SparkConf = new SparkConf().setMaster("local").setAppName("MongoSparkConnector")
+    .set("spark.mongodb.input.uri", "mongodb://example.com/test.test")
+    .set("spark.mongodb.output.uri", "mongodb://example.com/test.test")
+  val sc: SparkContext = new SparkContext(conf)
 
   override def beforeEach(): Unit = {
   }
@@ -71,3 +74,4 @@ class NoSparkConfSpec extends RequiresMongoDB {
   }
 
 }
+

--- a/src/test/scala/com/mongodb/spark/rdd/partitioner/BsonValueOrderingSpec.scala
+++ b/src/test/scala/com/mongodb/spark/rdd/partitioner/BsonValueOrderingSpec.scala
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2016 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.spark.rdd.partitioner
+
+import scala.collection.JavaConverters._
+import scala.util.Random
+
+import org.bson.types.ObjectId
+import org.bson.{BsonDbPointer, _}
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class BsonValueOrderingSpec extends FlatSpec with Matchers {
+  // scalastyle:off magic.number
+
+  private val objectId = new ObjectId("000000000000000000000000")
+  private val allBsonTypesDocument: BsonDocument = {
+    val document = new BsonDocument()
+    document.put("nullValue", new BsonNull())
+    document.put("int32", new BsonInt32(42))
+    document.put("int64", new BsonInt64(52L))
+    document.put("boolean", new BsonBoolean(true))
+    document.put("date", new BsonDateTime(1463497097))
+    document.put("double", new BsonDouble(62.0))
+    document.put("string", new BsonString("spark connector"))
+    document.put("minKey", new BsonMinKey())
+    document.put("maxKey", new BsonMaxKey())
+    document.put("objectId", new BsonObjectId(objectId))
+    document.put("code", new BsonJavaScript("int i = 0;"))
+    document.put("codeWithScope", new BsonJavaScriptWithScope("int x = y", new BsonDocument("y", new BsonInt32(1))))
+    document.put("regex", new BsonRegularExpression("^test.*regex.*xyz$", "i"))
+    document.put("symbol", new BsonSymbol("ruby stuff"))
+    document.put("timestamp", new BsonTimestamp(0x12345678, 5))
+    document.put("undefined", new BsonUndefined())
+    document.put("binary", new BsonBinary(Array[Byte](5, 4, 3, 2, 1)))
+    document.put("oldBinary", new BsonBinary(BsonBinarySubType.OLD_BINARY, Array[Byte](1, 1, 1, 1, 1)))
+    document.put("arrayInt", new BsonArray(List(new BsonInt32(1), new BsonInt32(2), new BsonInt32(3)).asJava))
+    document.put("document", new BsonDocument("a", new BsonInt32(1)))
+    document.put("dbPointer", new BsonDbPointer("db.coll", objectId))
+    document
+  }
+  val allBsonTypes: Seq[(String, BsonValue)] = allBsonTypesDocument.entrySet().asScala.map(e => (e.getKey, e.getValue)).toSeq
+
+  val orderedKeys = Seq("minKey", "nullValue", "int32", "int64", "double", "symbol", "string", "document", "arrayInt", "binary",
+    "oldBinary", "objectId", "boolean", "date", "timestamp", "regex", "maxKey")
+
+  val undefinedOrderingKeys = Seq("dbPointer", "undefined", "code", "codeWithScope")
+
+  implicit object BsonValueOrdering extends BsonValueOrdering
+
+  "The BsonValueOrdering trait" should "order all bson types correctly" in {
+    val data = allBsonTypes.filter({ case kv => orderedKeys.contains(kv._1) }).map(_._2)
+    val ordered = Random.shuffle(data).sorted
+    ordered should equal(orderedKeys.map(allBsonTypesDocument.get(_)))
+  }
+
+  it should "compare numbers types correctly" in {
+    val data: Seq[BsonValue] = Seq(new BsonInt32(1), new BsonInt64(2), new BsonDouble(3.0), new BsonDouble(4.0), new BsonInt64(5), new BsonInt32(6))
+    val ordered = Random.shuffle(data).sorted
+    ordered should equal(data)
+
+    val longAndDoubleData: Seq[BsonValue] = Seq(
+      new BsonDouble(Double.NegativeInfinity),
+      new BsonDouble(Long.MinValue), new BsonInt64(Long.MinValue + 1),
+      new BsonDouble(Double.MinPositiveValue), new BsonInt64(1L),
+      new BsonInt64(Long.MaxValue), new BsonDouble(Long.MaxValue),
+      new BsonDouble(Double.PositiveInfinity)
+    )
+
+    val orderedLongsAndDouble = Random.shuffle(longAndDoubleData).sorted
+    orderedLongsAndDouble should equal(longAndDoubleData)
+  }
+
+  it should "compare string types correctly" in {
+    val data: Seq[BsonValue] = Seq(new BsonString("12345"), new BsonSymbol("a"), new BsonSymbol("b"), new BsonSymbol("c 1"),
+      new BsonString("c 2"), new BsonSymbol("d"), new BsonString("e"))
+    val ordered = Random.shuffle(data).sorted
+    ordered should equal(data)
+  }
+
+  it should "compare timestamp types correctly" in {
+    val data: Seq[BsonValue] = Seq(new BsonTimestamp(1, 5), new BsonTimestamp(1, 6), new BsonTimestamp(2, 1),
+      new BsonTimestamp(2, 10), new BsonTimestamp(3, 0), new BsonTimestamp(3, 1), new BsonTimestamp(10010101, 0))
+    val ordered = Random.shuffle(data).sorted
+    ordered should equal(data)
+  }
+
+  it should "compare binary types correctly" in {
+    val data: Seq[BsonValue] = Seq(
+      new BsonBinary(BsonBinarySubType.BINARY, Array[Byte](1, 1, 1, 1, 1)),
+      new BsonBinary(BsonBinarySubType.OLD_BINARY, Array[Byte](1, 1, 1, 1, 1)),
+      new BsonBinary(BsonBinarySubType.OLD_BINARY, Array[Byte](2, 2, 2, 2, 2, 2)),
+      new BsonBinary(BsonBinarySubType.OLD_BINARY, Array[Byte](2, 2, 2, 2, 2, 2, 2)),
+      new BsonBinary(BsonBinarySubType.OLD_BINARY, Array[Byte](2, 2, 2, 2, 2, 2, 3))
+    )
+    val ordered = Random.shuffle(data).sorted
+    ordered should equal(data)
+  }
+
+  it should "compare array types correctly" in {
+    val data: Seq[BsonValue] = Seq(
+      new BsonArray(List(new BsonInt32(1)).asJava),
+      new BsonArray(List(new BsonInt32(1), new BsonInt32(2)).asJava),
+      new BsonArray(List(new BsonInt32(1), new BsonInt32(2), new BsonInt32(3)).asJava),
+      new BsonArray(List(new BsonString("1")).asJava)
+    )
+    val ordered = Random.shuffle(data).sorted
+    ordered should equal(data)
+  }
+
+  it should "compare regex types correctly" in {
+    val data: Seq[BsonValue] = Seq(
+      new BsonRegularExpression(".*"),
+      new BsonRegularExpression(".*", "i"),
+      new BsonRegularExpression("[0-9a-z]+"),
+      new BsonRegularExpression("[a-z]+")
+    )
+    val ordered = Random.shuffle(data).sorted
+    ordered should equal(data)
+  }
+
+  it should "compare document types correctly" in {
+    val data: Seq[BsonValue] = Seq(
+      BsonDocument.parse("""{}"""),
+      BsonDocument.parse("""{a: -1}"""),
+      BsonDocument.parse("""{a: 0}"""),
+      BsonDocument.parse("""{a: 1}"""),
+      BsonDocument.parse("""{a: 1, b: 1}"""),
+      BsonDocument.parse("""{a: 2}"""),
+      BsonDocument.parse("""{a: 9, b: 1}"""),
+      BsonDocument.parse("""{a: 10, b: 0}"""),
+      BsonDocument.parse("""{a: 100, b: 10}"""),
+      BsonDocument.parse("""{a: 1000, b: 10}"""),
+      BsonDocument.parse("""{a: 1000, b: 10, c: -1}"""),
+      BsonDocument.parse("""{a: "1", b: 0}""")
+    )
+    val ordered = Random.shuffle(data).sorted
+    ordered should equal(data)
+  }
+
+  it should "have no defined order for undefined types" in {
+    val data: Seq[BsonValue] = allBsonTypes.filter({ case kv => undefinedOrderingKeys.contains(kv._1) }).map(_._2)
+    val randomised = Random.shuffle(data)
+    val ordered = randomised.sorted
+    ordered should equal(randomised)
+  }
+  // scalastyle:on magic.number
+}

--- a/src/test/scala/com/mongodb/spark/rdd/partitioner/MongoPaginateByCountPartitionerSpec.scala
+++ b/src/test/scala/com/mongodb/spark/rdd/partitioner/MongoPaginateByCountPartitionerSpec.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2016 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.spark.rdd.partitioner
+
+import org.bson._
+import com.mongodb.spark._
+
+class MongoPaginateByCountPartitionerSpec extends RequiresMongoDB {
+
+  private val partitionKey = "_id"
+  private val pipeline = Array.empty[BsonDocument]
+
+  "MongoPaginateByCountPartitioner" should "partition the database as expected" in withSparkContext() { sc =>
+    sc.parallelize((0 to 1000).map(i => BsonDocument.parse(s"{ _id: $i }"))).saveToMongoDB()
+
+    val rightHandBoundaries = (0 to 1000 by 100).map(x => new BsonInt32(x))
+    val locations = PartitionerHelper.locations(MongoConnector(sparkConf))
+    val expectedPartitions = PartitionerHelper.createPartitions(partitionKey, rightHandBoundaries, locations)
+    val partitions = MongoPaginateByCountPartitioner.partitions(
+      mongoConnector,
+      readConfig.copy(partitionerOptions = Map("numberOfPartitions" -> "10")), pipeline
+    )
+
+    partitions should equal(expectedPartitions)
+  }
+
+  it should "handle fewer documents than partitions" in withSparkContext() { sc =>
+    sc.parallelize((0 to 10).map(i => BsonDocument.parse(s"{ _id: $i }"))).saveToMongoDB()
+
+    val rightHandBoundaries = (0 to 10).map(x => new BsonInt32(x))
+    val locations = PartitionerHelper.locations(MongoConnector(sparkConf))
+    val expectedPartitions = PartitionerHelper.createPartitions(partitionKey, rightHandBoundaries, locations)
+    val partitions = MongoPaginateByCountPartitioner.partitions(
+      mongoConnector,
+      readConfig.copy(partitionerOptions = Map("numberOfPartitions" -> "100")), pipeline
+    )
+    partitions should equal(expectedPartitions)
+  }
+
+  it should "handle no collection" in {
+    val expectedPartitions = MongoPaginateByCountPartitioner.partitions(mongoConnector, readConfig, pipeline)
+    MongoPaginateByCountPartitioner.partitions(mongoConnector, readConfig, pipeline) should equal(expectedPartitions)
+  }
+}

--- a/src/test/scala/com/mongodb/spark/rdd/partitioner/MongoPaginateBySizePartitionerSpec.scala
+++ b/src/test/scala/com/mongodb/spark/rdd/partitioner/MongoPaginateBySizePartitionerSpec.scala
@@ -16,46 +16,47 @@
 
 package com.mongodb.spark.rdd.partitioner
 
-import org.bson.{BsonDocument, Document}
+import org.bson._
 import com.mongodb.spark.{MongoConnector, RequiresMongoDB}
 
-class MongoSplitVectorPartitionerSpec extends RequiresMongoDB {
+class MongoPaginateBySizePartitionerSpec extends RequiresMongoDB {
 
   private val partitionKey = "_id"
   private val pipeline = Array.empty[BsonDocument]
 
   // scalastyle:off magic.number
-  "MongoSplitVectorPartitioner" should "partition the database as expected" in {
-    if (isSharded) cancel("Sharded MongoDB")
-    loadSampleData(5)
+  "MongoPaginateBySizePartitioner" should "partition the database as expected" in {
+    if (!serverAtLeast(3, 2)) cancel("Testing on wiretiger only, so to have predictable partition sizes.")
+    loadSampleData(10)
 
+    val rightHandBoundaries = (1 to 100 by 10).map(x => new BsonString(f"$x%05d"))
     val locations = PartitionerHelper.locations(MongoConnector(sparkConf))
-    val partitions = MongoSplitVectorPartitioner.partitions(
+    val expectedPartitions = PartitionerHelper.createPartitions(partitionKey, rightHandBoundaries, locations)
+    val partitions = MongoPaginateBySizePartitioner.partitions(
       mongoConnector,
       readConfig.copy(partitionerOptions = Map("partitionSizeMB" -> "1")), pipeline
     )
-    val zipped: Array[(MongoPartition, MongoPartition)] = partitions zip partitions.tail
-    zipped.foreach({
-      case (lt, gte) => lt.queryBounds.get("lt") should equal(gte.queryBounds.get("gte"))
-    })
-    partitions.length should be >= 5
-    partitions.head.locations should equal(locations)
 
-    MongoSplitVectorPartitioner.partitions(
+    partitions should equal(expectedPartitions)
+
+    val singlePartition = PartitionerHelper.createPartitions(partitionKey, Seq.empty[BsonValue], locations)
+    val largerSizedPartitions = MongoPaginateBySizePartitioner.partitions(
       mongoConnector,
       readConfig.copy(partitionerOptions = Map("partitionSizeMB" -> "10")), pipeline
-    ).length shouldBe 1
+    )
+    largerSizedPartitions should equal(singlePartition)
   }
   // scalastyle:on magic.number
 
   it should "have a default bounds of min to max key" in {
     collection.insertOne(new Document())
     val expectedPartitions = MongoSinglePartitioner.partitions(mongoConnector, readConfig, pipeline)
-    MongoSplitVectorPartitioner.partitions(mongoConnector, readConfig, pipeline) should equal(expectedPartitions)
+    MongoPaginateBySizePartitioner.partitions(mongoConnector, readConfig, pipeline) should equal(expectedPartitions)
   }
 
   it should "handle no collection" in {
     val expectedPartitions = MongoSinglePartitioner.partitions(mongoConnector, readConfig, pipeline)
-    MongoSplitVectorPartitioner.partitions(mongoConnector, readConfig, pipeline) should equal(expectedPartitions)
+    MongoPaginateBySizePartitioner.partitions(mongoConnector, readConfig, pipeline) should equal(expectedPartitions)
   }
 }
+

--- a/src/test/scala/com/mongodb/spark/rdd/partitioner/PartitionerHelperSpec.scala
+++ b/src/test/scala/com/mongodb/spark/rdd/partitioner/PartitionerHelperSpec.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.spark.rdd.partitioner
+
+import org.bson.{BsonDocument, BsonInt32}
+import com.mongodb.spark.RequiresMongoDB
+
+class PartitionerHelperSpec extends RequiresMongoDB {
+
+  "PartitionerHelper" should "create the expected partitions query" in {
+    val query = PartitionerHelper.createBoundaryQuery("_id", new BsonInt32(1), new BsonInt32(2))
+    query should equal(BsonDocument.parse("{_id: {$gte: 1, $lt: 2 }}"))
+  }
+
+  it should "create the correct partitions" in {
+    val partitions = PartitionerHelper.createPartitions("_id", Seq(new BsonInt32(10), new BsonInt32(20), new BsonInt32(30)), Seq("localhost")) // scalastyle:ignore
+    val expectedPartitions = Array(
+      MongoPartition(0, BsonDocument.parse("{_id: {$gte: { $minKey: 1 }, $lt: 10 }}"), Seq("localhost")),
+      MongoPartition(1, BsonDocument.parse("{_id: {$gte: 10, $lt: 20 }}"), Seq("localhost")),
+      MongoPartition(2, BsonDocument.parse("{_id: {$gte: 20, $lt: 30 }}"), Seq("localhost")),
+      MongoPartition(3, BsonDocument.parse("{_id: {$gte: 30, $lt: { $maxKey: 1 }}}"), Seq("localhost"))
+    )
+    partitions should be(expectedPartitions)
+  }
+}

--- a/src/test/scala/com/mongodb/spark/rdd/partitioner/TestPartitioner.scala
+++ b/src/test/scala/com/mongodb/spark/rdd/partitioner/TestPartitioner.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2016 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.spark.rdd.partitioner
+
+import scala.util.{Failure, Success, Try}
+
+import org.bson.{BsonDocument, Document}
+import com.mongodb.MongoCommandException
+import com.mongodb.spark.MongoConnector
+import com.mongodb.spark.config.ReadConfig
+
+/**
+ * The test collection partitioner implementation
+ *
+ * Checks if the collection is sharded then:
+ *  - If sharded uses the [[MongoShardedPartitioner]] to partition the collection by shard chunks
+ *  - If non sharded uses the [[MongoSplitVectorPartitioner]] to partition the collection by using the `splitVector` command.
+ *
+ * @since 1.0
+ */
+case object TestPartitioner extends MongoPartitioner {
+
+  override def partitions(connector: MongoConnector, readConfig: ReadConfig, pipeline: Array[BsonDocument]): Array[MongoPartition] = {
+    val collStatsCommand: Document = new Document("collStats", readConfig.collectionName)
+    val partitioner = Try(connector.withDatabaseDo(readConfig, { db => db.runCommand(collStatsCommand) })) match {
+      case Success(result) => result.getBoolean("sharded").asInstanceOf[Boolean] match {
+        case true  => MongoShardedPartitioner
+        case false => MongoSplitVectorPartitioner
+      }
+      case Failure(ex: MongoCommandException) if ex.getErrorMessage.endsWith("not found.") =>
+        logWarning(s"Could not find collection (${readConfig.collectionName}), using single partition")
+        MongoSinglePartitioner
+      case Failure(e) => throw e
+    }
+    partitioner.partitions(connector, readConfig, pipeline)
+  }
+
+}


### PR DESCRIPTION
Patitioners are now configurable via options and used in the ReadConfig
Partition errors are now passed onto the user.
Partitioning non-existent collections still return a single partition.
Partition configs: splitKey renamed to partitionKey, maxChunkSize renamed to partitionSizeMB.
SplitVector partitioner no longer the default single node partitioner.

Added three new partitioners:

 * MongoFixedNumberPartitioner, partitions the collection into a fixed number of partitions.
 * MongoPaginationPartitioner, uses the average document size and queries to calculate partitions.
 * MongoSamplePartitioner, uses over sampling and the average document size of a collection to calculate partitions.

SPARK-60 SPARK-54 SPARK-53 SPARK-51