### PR TITLE
Added support for SparkSession

### DIFF
--- a/doc/1-sparkSQL.md
+++ b/doc/1-sparkSQL.md
@@ -45,9 +45,9 @@ First enable the Mongo Connector specific functions on the `SQLContext`:
 import com.mongodb.spark.sql._
 ```
 
-### DataFrames and Datasets
+### Datasets
 
-The Mongo Spark Connector provides the `com.mongodb.spark.sql.DefaultSource` class that creates DataFrames and Datasets from MongoDB.
+The Mongo Spark Connector provides the `com.mongodb.spark.sql.DefaultSource` class that creates Datasets from MongoDB.
 However, the easiest way to create a DataFrame is by using the `MongoSpark` helper:
 
 ```scala
@@ -63,6 +63,8 @@ root
  |-- age: integer (nullable = true)
  |-- name: string (nullable = true)
 ```
+
+*Note:* In Spark 2.0 the `DataFrame` class became a type alias to `DataSet[Row]`.
 
 -----
 `MongoSpark.load(sqlContext)` is shorthand for configuring and loading via the DataFrameReader. The following examples are alternative
@@ -99,7 +101,7 @@ df.filter(df("age") < 100).show()
 ```
 
 -----
-*Note:* Unlike RDD's when using `filters` with DataFrames or SparkSQL the underlying Mongo Connector code will construct an aggregation 
+*Note:* Unlike RDD's when using `filters` with Datasets or SparkSQL the underlying Mongo Connector code will construct an aggregation 
 pipeline to filter the data in MongoDB before sending it to Spark.
 
 -----
@@ -130,7 +132,7 @@ root
 
 ```
 
-The following example converts the `DataFrame` into a `Dataset`:
+The following example converts the `DataFrame` into a `Dataset`. Or more correctly converts `Dataset[Row]` to `Dataset[Character]`:
 
 ```scala
 explicitDF.as[Character]
@@ -148,7 +150,7 @@ val dataset = MongoSpark.load[Character](sqlContext).as[Character]()
 
 ### SQL queries
 
-Spark SQL works on top of DataFrames, to be able to use SQL you need to register a temporary table first and then you can run SQL queries
+Spark SQL works on top of Datasets, to be able to use SQL you need to register a temporary table first and then you can run SQL queries
 over the data.
 
 The following example registers a "characters" table and then queries it to find all characters that are 100 or older.
@@ -166,7 +168,7 @@ centenarians.show()
 
 -----
 
-### Saving DataFrames
+### Saving Datasets
 
 The connector provides the ability to persist data into MongoDB.
 
@@ -206,8 +208,8 @@ dataFrameWriter.write.format("com.mongodb.spark.sql").save()
 
 ## DataTypes
 
-Spark supports a limited number of data types, to ensure that all bson types can be round tripped in and out of Spark DataFrames / 
-Datasets. Custom StructTypes are created for any unsupported Bson Types. The following table shows the mapping between the Bson Types and 
+Spark supports a limited number of data types, to ensure that all bson types can be round tripped in and out of Spark Datasets. 
+Custom StructTypes are created for any unsupported Bson Types. The following table shows the mapping between the Bson Types and 
 Spark Types:
 
 Bson Type               | Spark Type

--- a/doc/3-java-api.md
+++ b/doc/3-java-api.md
@@ -105,9 +105,11 @@ System.out.println(aggregatedRdd.count());
 System.out.println(aggregatedRdd.first().toJson());
 ```
 
-## DataFrames and Datasets
+## Datasets
 
-Creating a dataframe is easy you can either load the data via `DefaultSource` or use the `JavaMongoRDD#toDF` method.
+Creating a Dataset is easy you can either load the data via `DefaultSource` or use the `JavaMongoRDD#toDF` method.
+
+*Note:* In Spark 2.0 the `DataFrame` class became a type alias to `DataSet<Row>`. Java code must be updated to explicitly use `DataSet<Row>`.
 
 First, in an empty collection we load the following data:
 
@@ -136,7 +138,7 @@ Then to load the characters into a DataFrame via the standard source method:
 
 ```java
 SQLContext sqlContext = SQLContext.getOrCreate(jsc.sc());
-DataFrame df = MongoSpark.load(jsc).toDF();
+Dataset<Row> df = MongoSpark.load(jsc).toDF();
 df.printSchema();
 ```
 
@@ -156,7 +158,7 @@ If you know the shape of your documents then you can use a simple java bean to d
 In the following example we define a `Character` Java bean and pass that to the `toDF` method:
 
 ```java
-DataFrame explicitDF = MongoSpark.load(sqlContext).toDF(Character.class);
+Dataset<Row> explicitDF = MongoSpark.load(sqlContext).toDF(Character.class);
 explicitDF.printSchema();
 ```
 Will return:
@@ -179,12 +181,12 @@ the characters with ages under 100:
 
 ```java
 explicitDF.registerTempTable("characters");
-DataFrame centenarians = sqlContext.sql("SELECT name, age FROM characters WHERE age >= 100");
+Dataset<Row> centenarians = sqlContext.sql("SELECT name, age FROM characters WHERE age >= 100");
 ```
 
 *Note:* You must use the same `SQLContext` that registers the table and queries it. 
 
-### Saving DataFrames
+### Saving Datasets
 
 The connector provides the ability to persist data into MongoDB.
 

--- a/doc/3-java-api.md
+++ b/doc/3-java-api.md
@@ -137,7 +137,6 @@ MongoSpark.save(jsc.parallelize(characters).map(new Function<String, Document>()
 Then to load the characters into a DataFrame via the standard source method:
 
 ```java
-SQLContext sqlContext = SQLContext.getOrCreate(jsc.sc());
 Dataset<Row> df = MongoSpark.load(jsc).toDF();
 df.printSchema();
 ```
@@ -152,13 +151,15 @@ root
 ```
 
 
-By default reading from MongoDB in a `SQLContext` infers the schema by sampling documents from the database. 
+By default reading from MongoDB in a `SparkSession` infers the schema by sampling documents from the database. 
 If you know the shape of your documents then you can use a simple java bean to define the schema instead, thus preventing the extra queries.
 
 In the following example we define a `Character` Java bean and pass that to the `toDF` method:
 
 ```java
-Dataset<Row> explicitDF = MongoSpark.load(sqlContext).toDF(Character.class);
+
+SparkSession sparkSession = SparkSession.builder().getOrCreate();
+Dataset<Row> explicitDF = MongoSpark.load(sparkSession).toDF(Character.class);
 explicitDF.printSchema();
 ```
 Will return:

--- a/doc/6-FAQ.md
+++ b/doc/6-FAQ.md
@@ -39,8 +39,8 @@ val wordCounts = pairs.reduceByKey(_ + _)
 
 // Save the word counts for each 1 Second time window into MongoDB
 wordCounts.foreachRDD({ rdd =>
-  val sqlContext = SQLContext.getOrCreate(rdd.sparkContext)
-  import sqlContext.implicits._
+  val sparkSession = SparkSession.builder().getOrCreate()
+  import sparkSession.implicits._
 
   val wordCounts = rdd.map({ case (word: String, count: Int) => WordCount(word, count) }).toDF()
 

--- a/doc/7-Changelog.md
+++ b/doc/7-Changelog.md
@@ -2,6 +2,7 @@
 
 ## 2.0.0
 
+  * [[SPARK-47](https://jira.mongodb.org/browse/SPARK-47)] Updated API to use SparkSession and deprecated public methods using SQLContext.
   * [[SPARK-20](https://jira.mongodb.org/browse/SPARK-20)] Updated Spark Version to 2.0.0
 
 ------

--- a/doc/7-Changelog.md
+++ b/doc/7-Changelog.md
@@ -1,5 +1,11 @@
 # Mongo Spark Connector Changelog
 
+## 2.0.0
+
+  * [[SPARK-20](https://jira.mongodb.org/browse/SPARK-20)] Updated Spark Version to 2.0.0
+
+------
+
 ## 0.4
   * [[SPARK-49](https://jira.mongodb.org/browse/SPARK-49)] Marked internal public code with DeveloperApi annotation.
   * [[SPARK-60](https://jira.mongodb.org/browse/SPARK-60)] Added partitioner to ReadConfig and added custom partitioner options.

--- a/examples/src/test/java/tour/JavaIntroduction.java
+++ b/examples/src/test/java/tour/JavaIntroduction.java
@@ -22,12 +22,12 @@ import com.mongodb.spark.MongoSpark;
 import com.mongodb.spark.config.ReadConfig;
 import com.mongodb.spark.config.WriteConfig;
 import com.mongodb.spark.rdd.api.java.JavaMongoRDD;
-
 import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.api.java.function.Function;
-import org.apache.spark.sql.DataFrame;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SQLContext;
 import org.bson.Document;
 
@@ -98,7 +98,7 @@ public final class JavaIntroduction {
         System.out.println(aggregatedRdd.count());
         System.out.println(aggregatedRdd.first().toJson());
 
-        // DataFrames
+        // Datasets
 
         // Drop database
         dropDatabase(getMongoClientURI(args));
@@ -126,17 +126,17 @@ public final class JavaIntroduction {
 
         // Load inferring schema
         SQLContext sqlContext = SQLContext.getOrCreate(jsc.sc());
-        DataFrame df = MongoSpark.load(jsc).toDF();
+        Dataset<Row> df = MongoSpark.load(jsc).toDF();
         df.printSchema();
         df.show();
 
         // Declare the Schema via a Java Bean
-        DataFrame explicitDF = MongoSpark.load(jsc).toDF(Character.class);
+        Dataset<Row> explicitDF = MongoSpark.load(jsc).toDF(Character.class);
         explicitDF.printSchema();
 
         // SQL
         explicitDF.registerTempTable("characters");
-        DataFrame centenarians = sqlContext.sql("SELECT name, age FROM characters WHERE age >= 100");
+        Dataset<Row> centenarians = sqlContext.sql("SELECT name, age FROM characters WHERE age >= 100");
 
         // Saving DataFrame
         MongoSpark.write(centenarians).option("collection", "hundredClub").save();

--- a/examples/src/test/java/tour/JavaIntroduction.java
+++ b/examples/src/test/java/tour/JavaIntroduction.java
@@ -28,7 +28,7 @@ import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.api.java.function.Function;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
-import org.apache.spark.sql.SQLContext;
+import org.apache.spark.sql.SparkSession;
 import org.bson.Document;
 
 import java.util.HashMap;
@@ -125,22 +125,22 @@ public final class JavaIntroduction {
 
 
         // Load inferring schema
-        SQLContext sqlContext = SQLContext.getOrCreate(jsc.sc());
         Dataset<Row> df = MongoSpark.load(jsc).toDF();
         df.printSchema();
         df.show();
 
         // Declare the Schema via a Java Bean
+        SparkSession sparkSession = SparkSession.builder().getOrCreate();
         Dataset<Row> explicitDF = MongoSpark.load(jsc).toDF(Character.class);
         explicitDF.printSchema();
 
         // SQL
         explicitDF.registerTempTable("characters");
-        Dataset<Row> centenarians = sqlContext.sql("SELECT name, age FROM characters WHERE age >= 100");
+        Dataset<Row> centenarians = sparkSession.sql("SELECT name, age FROM characters WHERE age >= 100");
 
         // Saving DataFrame
         MongoSpark.write(centenarians).option("collection", "hundredClub").save();
-        MongoSpark.load(sqlContext, ReadConfig.create(sqlContext).withOption("collection", "hundredClub"), Character.class).show();
+        MongoSpark.load(sparkSession, ReadConfig.create(sparkSession).withOption("collection", "hundredClub"), Character.class).show();
     }
 
     private static JavaSparkContext createJavaSparkContext(final String[] args) {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,7 +21,7 @@ object Dependencies {
   val scalaCoreVersion        = "2.11.7"
   val scalaVersions           = Seq("2.11.7", "2.10.6")
   val mongodbDriverVersion    = "3.2.2"
-  val sparkVersion            = "1.6.1"
+  val sparkVersion            = "2.0.0-SNAPSHOT"
   val slf4jVersion            = "1.7.16"
 
   val scalaTestVersion        = "2.2.4"

--- a/project/Resolvers.scala
+++ b/project/Resolvers.scala
@@ -23,7 +23,9 @@ object Resolvers {
   val typeSafeSnaps = "TypeSafe snapshots" at "http://repo.typesafe.com/typesafe/snapshots"
   val typeSafeRels  = "TypeSafe releases" at "http://repo.typesafe.com/typesafe/releases"
 
-  val localMaven    = "Local Maven Repository" at "file://"+Path.userHome.absolutePath+"/.m2/repository"
+  val apacheSnaps   = "Apache snapshots" at "http://repository.apache.org/snapshots/"
 
-  val mongoScalaResolvers = Seq(sonatypeSnaps, localMaven, sonatypeRels, typeSafeSnaps, typeSafeRels)
+  val localMaven    = s"Local Maven Repository" at s"file://${Path.userHome.absolutePath}/.m2/repository"
+
+  val mongoScalaResolvers = Seq(sonatypeSnaps, apacheSnaps, localMaven, sonatypeRels, typeSafeSnaps, typeSafeRels)
 }

--- a/src/main/scala/com/mongodb/spark/MongoSpark.scala
+++ b/src/main/scala/com/mongodb/spark/MongoSpark.scala
@@ -139,7 +139,7 @@ object MongoSpark {
    *
    * @param dataFrameWriter the DataFrameWriter save to MongoDB
    */
-  def save(dataFrameWriter: DataFrameWriter): Unit = dataFrameWriter.format(defaultSource).save()
+  def save(dataFrameWriter: DataFrameWriter[_]): Unit = dataFrameWriter.format(defaultSource).save()
 
   /**
    * Save data to MongoDB
@@ -147,7 +147,7 @@ object MongoSpark {
    * @param dataFrameWriter the DataFrameWriter save to MongoDB
    * @param writeConfig the writeConfig
    */
-  def save(dataFrameWriter: DataFrameWriter, writeConfig: WriteConfig): Unit =
+  def save(dataFrameWriter: DataFrameWriter[_], writeConfig: WriteConfig): Unit =
     dataFrameWriter.format(defaultSource).options(writeConfig.asOptions).save()
 
   /**
@@ -164,7 +164,7 @@ object MongoSpark {
    * @param dataFrame the DataFrame to convert into a DataFrameWriter
    * @return the DataFrameWriter
    */
-  def write(dataFrame: DataFrame): DataFrameWriter = dataFrame.write.format("com.mongodb.spark.sql")
+  def write(dataFrame: DataFrame): DataFrameWriter[Row] = dataFrame.write.format("com.mongodb.spark.sql")
 
   /**
    * Builder for configuring and creating a [[MongoSpark]]

--- a/src/main/scala/com/mongodb/spark/config/MongoCompanionConfig.scala
+++ b/src/main/scala/com/mongodb/spark/config/MongoCompanionConfig.scala
@@ -24,7 +24,7 @@ import org.apache.spark.{SparkConf, SparkContext}
 
 import com.mongodb.ConnectionString
 import org.apache.spark.api.java.JavaSparkContext
-import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.{SQLContext, SparkSession}
 
 /**
  * The Mongo configuration base trait
@@ -71,10 +71,22 @@ trait MongoCompanionConfig extends Serializable {
    * Uses the prefixed properties that are set in the Spark configuration to create the config.
    *
    * @see [[configPrefix]]
+   * @param sparkSession the SparkSession
+   * @return the configuration
+   */
+  def apply(sparkSession: SparkSession): Self = apply(sparkSession.sparkContext.getConf)
+
+  /**
+   * Create a configuration from the `sqlContext`
+   *
+   * Uses the prefixed properties that are set in the Spark configuration to create the config.
+   *
+   * @see [[configPrefix]]
    * @param sqlContext the SQL context
    * @return the configuration
    */
-  def apply(sqlContext: SQLContext): Self = apply(sqlContext.sparkContext.getConf)
+  @deprecated("As of Spark 2.0 SQLContext was replaced by SparkSession. Use the SparkSession method instead", "2.0.0")
+  def apply(sqlContext: SQLContext): Self = apply(sqlContext.sparkSession)
 
   /**
    * Create a configuration from the `sparkConf`
@@ -140,9 +152,21 @@ trait MongoCompanionConfig extends Serializable {
    * Uses the prefixed properties that are set in the Spark configuration to create the config.
    *
    * @see [[configPrefix]]
+   * @param sparkSession the SparkSession
+   * @return the configuration
+   */
+  def create(sparkSession: SparkSession): Self
+
+  /**
+   * Create a configuration easily from the Java API using the `JavaSparkContext`
+   *
+   * Uses the prefixed properties that are set in the Spark configuration to create the config.
+   *
+   * @see [[configPrefix]]
    * @param sqlContext the SQL context
    * @return the configuration
    */
+  @deprecated("As of Spark 2.0 SQLContext was replaced by SparkSession. Use the SparkSession method instead", "2.0.0")
   def create(sqlContext: SQLContext): Self
 
   /**

--- a/src/main/scala/com/mongodb/spark/config/ReadConcernConfig.scala
+++ b/src/main/scala/com/mongodb/spark/config/ReadConcernConfig.scala
@@ -27,7 +27,7 @@ import org.apache.spark.SparkConf
 
 import com.mongodb.{ReadConcern, ReadConcernLevel}
 import org.apache.spark.api.java.JavaSparkContext
-import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.{SQLContext, SparkSession}
 
 /**
  * The `ReadConcernConfig` companion object
@@ -109,9 +109,15 @@ object ReadConcernConfig extends MongoInputConfig {
     apply(sparkConf, options.asScala)
   }
 
+  @deprecated("As of Spark 2.0 SQLContext was replaced by SparkSession. Use the SparkSession method instead", "2.0.0")
   override def create(sqlContext: SQLContext): ReadConcernConfig = {
     notNull("sqlContext", sqlContext)
-    apply(sqlContext)
+    create(sqlContext.sparkSession)
+  }
+
+  override def create(sparkSession: SparkSession): ReadConcernConfig = {
+    notNull("sparkSession", sparkSession)
+    apply(sparkSession)
   }
 }
 

--- a/src/main/scala/com/mongodb/spark/config/ReadConfig.scala
+++ b/src/main/scala/com/mongodb/spark/config/ReadConfig.scala
@@ -23,7 +23,7 @@ import scala.util.Try
 
 import org.apache.spark.SparkConf
 import org.apache.spark.api.java.JavaSparkContext
-import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.{SQLContext, SparkSession}
 
 import com.mongodb.spark.rdd.partitioner.{DefaultMongoPartitioner, MongoPartitioner}
 import com.mongodb.spark.{LoggingTrait, notNull}
@@ -103,9 +103,15 @@ object ReadConfig extends MongoInputConfig with LoggingTrait {
     apply(javaSparkContext.getConf)
   }
 
+  @deprecated("As of Spark 2.0 SQLContext was replaced by SparkSession. Use the SparkSession method instead", "2.0.0")
   override def create(sqlContext: SQLContext): ReadConfig = {
     notNull("sqlContext", sqlContext)
-    apply(sqlContext)
+    create(sqlContext.sparkSession)
+  }
+
+  override def create(sparkSession: SparkSession): ReadConfig = {
+    notNull("sparkSession", sparkSession)
+    apply(sparkSession)
   }
 
   override def create(sparkConf: SparkConf): ReadConfig = {
@@ -150,6 +156,7 @@ object ReadConfig extends MongoInputConfig with LoggingTrait {
     stripPrefix(options).map(kv => (kv._1.toLowerCase, kv._2))
       .filter(kv => kv._1.startsWith(partitionerOptionsProperty)).map(kv => (kv._1.stripPrefix(s"$partitionerOptionsProperty."), kv._2))
   }
+
 }
 
 /**

--- a/src/main/scala/com/mongodb/spark/config/ReadPreferenceConfig.scala
+++ b/src/main/scala/com/mongodb/spark/config/ReadPreferenceConfig.scala
@@ -27,7 +27,7 @@ import org.apache.spark.SparkConf
 import org.bson.Document
 import com.mongodb.{ReadPreference, Tag, TagSet, TaggableReadPreference}
 import org.apache.spark.api.java.JavaSparkContext
-import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.{SQLContext, SparkSession}
 
 /**
  * The `ReadPreferenceConfig` companion object
@@ -126,9 +126,15 @@ object ReadPreferenceConfig extends MongoInputConfig {
     apply(sparkConf, options.asScala)
   }
 
+  @deprecated("As of Spark 2.0 SQLContext was replaced by SparkSession. Use the SparkSession method instead", "2.0.0")
   override def create(sqlContext: SQLContext): ReadPreferenceConfig = {
     notNull("sqlContext", sqlContext)
-    apply(sqlContext)
+    create(sqlContext.sparkSession)
+  }
+
+  override def create(sparkSession: SparkSession): ReadPreferenceConfig = {
+    notNull("sparkSession", sparkSession)
+    apply(sparkSession)
   }
 
   private def tagSets(tagSets: String): util.List[TagSet] = {

--- a/src/main/scala/com/mongodb/spark/config/WriteConcernConfig.scala
+++ b/src/main/scala/com/mongodb/spark/config/WriteConcernConfig.scala
@@ -28,7 +28,7 @@ import org.apache.spark.SparkConf
 
 import com.mongodb.WriteConcern
 import org.apache.spark.api.java.JavaSparkContext
-import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.{SQLContext, SparkSession}
 
 import com.mongodb.spark.notNull
 
@@ -127,9 +127,15 @@ object WriteConcernConfig extends MongoOutputConfig {
     apply(sparkConf, options.asScala)
   }
 
+  @deprecated("As of Spark 2.0 SQLContext was replaced by SparkSession. Use the SparkSession method instead", "2.0.0")
   override def create(sqlContext: SQLContext): WriteConcernConfig = {
     notNull("sqlContext", sqlContext)
-    apply(sqlContext)
+    create(sqlContext.sparkSession)
+  }
+
+  override def create(sparkSession: SparkSession): WriteConcernConfig = {
+    notNull("sparkSession", sparkSession)
+    apply(sparkSession)
   }
 }
 

--- a/src/main/scala/com/mongodb/spark/config/WriteConfig.scala
+++ b/src/main/scala/com/mongodb/spark/config/WriteConfig.scala
@@ -23,7 +23,7 @@ import scala.util.Try
 
 import org.apache.spark.SparkConf
 import org.apache.spark.api.java.JavaSparkContext
-import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.{SQLContext, SparkSession}
 
 import com.mongodb.{ConnectionString, WriteConcern}
 import com.mongodb.spark.notNull
@@ -131,7 +131,12 @@ object WriteConfig extends MongoOutputConfig {
 
   override def create(sqlContext: SQLContext): WriteConfig = {
     notNull("sqlContext", sqlContext)
-    apply(sqlContext)
+    create(sqlContext.sparkSession)
+  }
+
+  override def create(sparkSession: SparkSession): WriteConfig = {
+    notNull("sparkSession", sparkSession)
+    apply(sparkSession)
   }
 
 }

--- a/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoPartition.scala
+++ b/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoPartition.scala
@@ -17,6 +17,7 @@
 package com.mongodb.spark.rdd.partitioner
 
 import scala.collection.JavaConverters._
+
 import org.apache.spark.Partition
 
 import org.bson.BsonDocument
@@ -67,4 +68,11 @@ object MongoPartition {
  *
  * @since 1.0
  */
-case class MongoPartition(index: Int, queryBounds: BsonDocument, locations: Seq[String]) extends Partition
+case class MongoPartition(index: Int, queryBounds: BsonDocument, locations: Seq[String]) extends Partition {
+  override def hashCode(): Int = super.hashCode()
+
+  override def equals(other: Any): Boolean = other match {
+    case p: MongoPartition if index.equals(p.index) && queryBounds.equals(p.queryBounds) && locations.equals(p.locations) => true
+    case _ => false
+  }
+}

--- a/src/main/scala/com/mongodb/spark/sql/DefaultSource.scala
+++ b/src/main/scala/com/mongodb/spark/sql/DefaultSource.scala
@@ -66,7 +66,7 @@ class DefaultSource extends DataSourceRegister with RelationProvider with Schema
   private def createRelation(sqlContext: SQLContext, parameters: Map[String, String], structType: Option[StructType]): MongoRelation = {
     val rdd = pipelinedRdd(
       MongoSpark.builder()
-        .sqlContext(sqlContext)
+        .sparkSession(sqlContext.sparkSession)
         .readConfig(ReadConfig(sqlContext.sparkContext.getConf, parameters))
         .build()
         .toRDD[BsonDocument](),

--- a/src/main/scala/com/mongodb/spark/sql/MongoDataFrameWriterFunctions.scala
+++ b/src/main/scala/com/mongodb/spark/sql/MongoDataFrameWriterFunctions.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.DataFrameWriter
 
 import com.mongodb.spark.config.WriteConfig
 
-class MongoDataFrameWriterFunctions(@transient val dfw: DataFrameWriter) extends Serializable with LoggingTrait {
+class MongoDataFrameWriterFunctions(@transient val dfw: DataFrameWriter[_]) extends Serializable with LoggingTrait {
 
   /**
    * Saves the contents of the `DataFrame` to MongoDB.

--- a/src/main/scala/com/mongodb/spark/sql/MongoInferSchema.scala
+++ b/src/main/scala/com/mongodb/spark/sql/MongoInferSchema.scala
@@ -23,7 +23,7 @@ import scala.reflect.runtime.universe._
 import scala.util.{Failure, Success, Try}
 
 import org.apache.spark.SparkContext
-import org.apache.spark.sql.catalyst.analysis.HiveTypeCoercion
+import org.apache.spark.sql.catalyst.analysis.TypeCoercion
 import org.apache.spark.sql.catalyst.{JavaTypeInference, ScalaReflection}
 import org.apache.spark.sql.types._
 
@@ -132,7 +132,7 @@ object MongoInferSchema {
    * @return the DataType that matches on the input DataTypes
    */
   private def compatibleType(t1: DataType, t2: DataType): DataType = {
-    HiveTypeCoercion.findTightestCommonTypeOfTwo(t1, t2).getOrElse {
+    TypeCoercion.findTightestCommonTypeOfTwo(t1, t2).getOrElse {
       // t1 or t2 is a StructType, ArrayType, or an unexpected type.
       (t1, t2) match {
         case (StructType(fields1), StructType(fields2)) =>

--- a/src/main/scala/com/mongodb/spark/sql/SparkSessionFunctions.scala
+++ b/src/main/scala/com/mongodb/spark/sql/SparkSessionFunctions.scala
@@ -18,7 +18,7 @@ package com.mongodb.spark.sql
 
 import scala.reflect.runtime.universe._
 
-import org.apache.spark.sql.{DataFrame, SQLContext}
+import org.apache.spark.sql.{DataFrame, SparkSession}
 
 import com.mongodb.spark.MongoSpark
 import com.mongodb.spark.annotation.DeveloperApi
@@ -27,13 +27,13 @@ import com.mongodb.spark.config.ReadConfig
 /**
  * :: DeveloperApi ::
  *
- * Helpers to create [[com.mongodb.spark.rdd.MongoRDD]] in the current `SQLContext`.
+ * Helpers to create [[com.mongodb.spark.rdd.MongoRDD]] in the current `SparkSession`.
  *
- * @param sqlContext the SQLContext
- * @since 1.0
+ * @param sparkSession the SparkSession
+ * @since 2.0
  */
 @DeveloperApi
-case class SparkSQLContextFunctions(@transient sqlContext: SQLContext) extends Serializable {
+case class SparkSessionFunctions(@transient sparkSession: SparkSession) extends Serializable {
 
   /**
    * Creates a MongoRDD
@@ -45,6 +45,6 @@ case class SparkSQLContextFunctions(@transient sqlContext: SQLContext) extends S
    *
    * @return a MongoRDD
    */
-  def loadFromMongoDB[T <: Product: TypeTag](readConfig: ReadConfig = ReadConfig(sqlContext.sparkContext)): DataFrame =
-    MongoSpark.builder().sqlContext(sqlContext).readConfig(readConfig).build().toDF[T]()
+  def loadFromMongoDB[T <: Product: TypeTag](readConfig: ReadConfig = ReadConfig(sparkSession.sparkContext)): DataFrame =
+    MongoSpark.builder().sparkSession(sparkSession).readConfig(readConfig).build().toDF[T]()
 }

--- a/src/main/scala/com/mongodb/spark/sql/package.scala
+++ b/src/main/scala/com/mongodb/spark/sql/package.scala
@@ -18,7 +18,7 @@ package com.mongodb.spark
 
 import scala.language.implicitConversions
 
-import org.apache.spark.sql.{DataFrameReader, DataFrameWriter, SQLContext}
+import org.apache.spark.sql.{DataFrameReader, DataFrameWriter, SQLContext, SparkSession}
 
 /**
  * The Mongo Spark Connector Sql package
@@ -31,7 +31,15 @@ package object sql {
    * @param sqlContext the current SQLContext
    * @return the MongoDB based SQLContext
    */
-  implicit def toSparkSQLContextFunctions(sqlContext: SQLContext): SparkSQLContextFunctions = SparkSQLContextFunctions(sqlContext)
+  implicit def toSparkSessionFunctions(sqlContext: SQLContext): SparkSessionFunctions = toSparkSessionFunctions(sqlContext.sparkSession)
+
+  /**
+   * Helper to implicitly add MongoDB based functions to a SQLContext
+   *
+   * @param sparkSession the current SparkSession
+   * @return the MongoDB based SQLContext
+   */
+  implicit def toSparkSessionFunctions(sparkSession: SparkSession): SparkSessionFunctions = SparkSessionFunctions(sparkSession)
 
   /**
    * Helper to implicitly add MongoDB based functions to a DataFrameReader

--- a/src/main/scala/com/mongodb/spark/sql/package.scala
+++ b/src/main/scala/com/mongodb/spark/sql/package.scala
@@ -31,6 +31,7 @@ package object sql {
    * @param sqlContext the current SQLContext
    * @return the MongoDB based SQLContext
    */
+  @deprecated("As of Spark 2.0 SQLContext was replaced by SparkSession. Use the SparkSession method instead", "2.0.0")
   implicit def toSparkSessionFunctions(sqlContext: SQLContext): SparkSessionFunctions = toSparkSessionFunctions(sqlContext.sparkSession)
 
   /**

--- a/src/main/scala/com/mongodb/spark/sql/package.scala
+++ b/src/main/scala/com/mongodb/spark/sql/package.scala
@@ -48,7 +48,7 @@ package object sql {
    * @param dfw the DataFrameWriter
    * @return the MongoDB based DataFrameWriter
    */
-  implicit def toMongoDataFrameWriterFunctions(dfw: DataFrameWriter): MongoDataFrameWriterFunctions =
+  implicit def toMongoDataFrameWriterFunctions(dfw: DataFrameWriter[_]): MongoDataFrameWriterFunctions =
     new MongoDataFrameWriterFunctions(dfw)
 
 }

--- a/src/test/java/com/mongodb/spark/MongoSparkTest.java
+++ b/src/test/java/com/mongodb/spark/MongoSparkTest.java
@@ -26,7 +26,7 @@ import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.api.java.function.FlatMapFunction;
 import org.apache.spark.api.java.function.Function;
 import org.apache.spark.api.java.function.MapFunction;
-import org.apache.spark.sql.DataFrame;
+import org.apache.spark.sql.Row;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.catalyst.JavaTypeInference;
@@ -137,7 +137,7 @@ public final class MongoSparkTest extends JavaRequiresMongoDB {
         StructType expectedSchema = createStructType(asList(_idField, countField));
 
         // when
-        DataFrame dataFrame = mongoRDD.toDF();
+        Dataset<Row> dataFrame = mongoRDD.toDF();
 
         // then
         assertEquals(dataFrame.schema(), expectedSchema);
@@ -154,7 +154,7 @@ public final class MongoSparkTest extends JavaRequiresMongoDB {
         StructType expectedSchema = (StructType) JavaTypeInference.inferDataType(Counter.class)._1();
 
         // when
-        DataFrame dataFrame = mongoRDD.toDF(Counter.class);
+        Dataset<Row> dataFrame = mongoRDD.toDF(Counter.class);
 
         // then
         assertEquals(dataFrame.schema(), expectedSchema);
@@ -244,13 +244,13 @@ public final class MongoSparkTest extends JavaRequiresMongoDB {
         assertEquals(mongoRDD.getNumPartitions(), 2);
         assertThat(mongoRDD.mapPartitions(new FlatMapFunction<Iterator<Document>, Integer>() {
             @Override
-            public Iterable<Integer> call(final Iterator<Document> iterator) throws Exception {
+            public Iterator<Integer> call(final Iterator<Document> iterator) throws Exception {
                 int i = 0;
                 while(iterator.hasNext()) {
                     i++;
                     iterator.next();
                 }
-                return singletonList(i);
+                return singletonList(i).iterator();
             }
         }).collect(), is(asList(50, 50)));
     }

--- a/src/test/java/com/mongodb/spark/NoSparkConfTest.java
+++ b/src/test/java/com/mongodb/spark/NoSparkConfTest.java
@@ -25,7 +25,7 @@ import org.apache.spark.SparkContext;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.api.java.function.Function;
 import org.apache.spark.sql.Encoders;
-import org.apache.spark.sql.SQLContext;
+import org.apache.spark.sql.SparkSession;
 import org.bson.Document;
 import org.junit.After;
 import org.junit.Test;
@@ -67,14 +67,14 @@ public final class NoSparkConfTest extends JavaRequiresMongoDB {
     @Test
     public void shouldBeAbleToUseConfigsWithDataFrames() {
         JavaSparkContext jsc = getJavaSparkContext();
-        SQLContext sqlContext = SQLContext.getOrCreate(jsc.sc());
+        SparkSession sparkSession = SparkSession.builder().getOrCreate();
         List<CharacterBean> characters = asList(new CharacterBean("Gandalf", 1000), new CharacterBean("Bilbo Baggins", 50));
 
-        MongoSpark.write(sqlContext.createDataFrame(jsc.parallelize(characters), CharacterBean.class))
+        MongoSpark.write(sparkSession.createDataFrame(jsc.parallelize(characters), CharacterBean.class))
                 .options(getOptions())
                 .save();
 
-        List<CharacterBean> ds = MongoSpark.read(sqlContext)
+        List<CharacterBean> ds = MongoSpark.read(sparkSession)
                 .options(getOptions())
                 .load()
                 .as(Encoders.bean(CharacterBean.class))

--- a/src/test/java/com/mongodb/spark/sql/MongoDataFrameReaderTest.java
+++ b/src/test/java/com/mongodb/spark/sql/MongoDataFrameReaderTest.java
@@ -19,7 +19,8 @@ package com.mongodb.spark.sql;
 import com.mongodb.spark.MongoSpark;
 import com.mongodb.spark.JavaRequiresMongoDB;
 import org.apache.spark.api.java.JavaSparkContext;
-import org.apache.spark.sql.DataFrame;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SQLContext;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructField;
@@ -56,7 +57,7 @@ public final class MongoDataFrameReaderTest extends JavaRequiresMongoDB {
         StructType expectedSchema = createStructType(asList(_idField, ageField, nameField));
 
         // When
-        DataFrame df = MongoSpark.load(jsc).toDF();
+        Dataset<Row> df = MongoSpark.load(jsc).toDF();
 
         // Then
         assertEquals(df.schema(), expectedSchema);
@@ -72,7 +73,7 @@ public final class MongoDataFrameReaderTest extends JavaRequiresMongoDB {
         StructType expectedSchema = createStructType(asList(_idField, ageField, nameField));
 
         // When
-        DataFrame df = MongoSpark.load(jsc).toDF();
+        Dataset<Row> df = MongoSpark.load(jsc).toDF();
 
         // Then
         assertEquals(df.schema(), expectedSchema);
@@ -88,7 +89,7 @@ public final class MongoDataFrameReaderTest extends JavaRequiresMongoDB {
         StructType expectedSchema = createStructType(asList(_idField, ageField, nameField));
 
         // When
-        DataFrame df = MongoSpark.load(jsc).toDF();
+        Dataset<Row> df = MongoSpark.load(jsc).toDF();
 
         // Then
         assertEquals(df.schema(), expectedSchema);
@@ -107,7 +108,7 @@ public final class MongoDataFrameReaderTest extends JavaRequiresMongoDB {
         StructType expectedSchema = createStructType(asList(_idField, ageField, nameField));
 
         // When
-        DataFrame df = sqlContext.read().format("com.mongodb.spark.sql").option("pipeline", "{ $match: { name: { $exists: true } } }").load();
+        Dataset<Row> df = sqlContext.read().format("com.mongodb.spark.sql").option("pipeline", "{ $match: { name: { $exists: true } } }").load();
 
         // Then
         assertEquals(df.schema(), expectedSchema);
@@ -131,7 +132,7 @@ public final class MongoDataFrameReaderTest extends JavaRequiresMongoDB {
         StructType expectedSchema = createStructType(asList(ageField, nameField));
 
         // When
-        DataFrame df = MongoSpark.load(jsc).toDF(CharacterBean.class);
+        Dataset<Row> df = MongoSpark.load(jsc).toDF(CharacterBean.class);
 
         // Then
         assertEquals(df.schema(), expectedSchema);
@@ -148,7 +149,7 @@ public final class MongoDataFrameReaderTest extends JavaRequiresMongoDB {
         StructType expectedSchema = createStructType(asList(ageField, nameField));
 
         // When
-        DataFrame df = MongoSpark.load(jsc).toDF(CharacterBean.class);
+        Dataset<Row> df = MongoSpark.load(jsc).toDF(CharacterBean.class);
 
         // Then
         assertEquals(df.schema(), expectedSchema);

--- a/src/test/java/com/mongodb/spark/sql/MongoDataFrameReaderTest.java
+++ b/src/test/java/com/mongodb/spark/sql/MongoDataFrameReaderTest.java
@@ -16,12 +16,12 @@
 
 package com.mongodb.spark.sql;
 
-import com.mongodb.spark.MongoSpark;
 import com.mongodb.spark.JavaRequiresMongoDB;
+import com.mongodb.spark.MongoSpark;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
-import org.apache.spark.sql.SQLContext;
+import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
@@ -104,11 +104,11 @@ public final class MongoDataFrameReaderTest extends JavaRequiresMongoDB {
         MongoSpark.save(jsc.parallelize(characters).map(JsonToDocument));
         MongoSpark.save(jsc.parallelize(asList("{counter: 1}", "{counter: 2}", "{counter: 3}")).map(JsonToDocument));
 
-        SQLContext sqlContext = SQLContext.getOrCreate(jsc.sc());
+        SparkSession sparkSession = SparkSession.builder().getOrCreate();
         StructType expectedSchema = createStructType(asList(_idField, ageField, nameField));
 
         // When
-        Dataset<Row> df = sqlContext.read().format("com.mongodb.spark.sql").option("pipeline", "{ $match: { name: { $exists: true } } }").load();
+        Dataset<Row> df = sparkSession.read().format("com.mongodb.spark.sql").option("pipeline", "{ $match: { name: { $exists: true } } }").load();
 
         // Then
         assertEquals(df.schema(), expectedSchema);
@@ -116,7 +116,7 @@ public final class MongoDataFrameReaderTest extends JavaRequiresMongoDB {
         assertEquals(df.filter("age > 100").count(), 6);
 
         // When - single item pipeline
-        df = sqlContext.read().format("com.mongodb.spark.sql").option("pipeline", "{ $match: { name: { $exists: true } } }").load();
+        df = sparkSession.read().format("com.mongodb.spark.sql").option("pipeline", "{ $match: { name: { $exists: true } } }").load();
 
         // Then
         assertEquals(df.schema(), expectedSchema);
@@ -162,7 +162,7 @@ public final class MongoDataFrameReaderTest extends JavaRequiresMongoDB {
         JavaSparkContext jsc = getJavaSparkContext();
         MongoSpark.save(jsc.parallelize(characters).map(JsonToDocument));
 
-        SQLContext.getOrCreate(jsc.sc()).read().format("com.mongodb.spark.sql").option("pipeline", "[1, 2, 3]").load();
+        SparkSession.builder().getOrCreate().read().format("com.mongodb.spark.sql").option("pipeline", "[1, 2, 3]").load();
     }
 
     private StructField _idField = createStructField("_id", ObjectIdStruct(), true);

--- a/src/test/java/com/mongodb/spark/sql/MongoDataFrameWriterTest.java
+++ b/src/test/java/com/mongodb/spark/sql/MongoDataFrameWriterTest.java
@@ -1,13 +1,13 @@
 package com.mongodb.spark.sql;
 
-import com.mongodb.spark.MongoSpark;
 import com.mongodb.spark.JavaRequiresMongoDB;
+import com.mongodb.spark.MongoSpark;
 import com.mongodb.spark.config.ReadConfig;
 import com.mongodb.spark.config.WriteConfig;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.api.java.function.Function;
-import org.apache.spark.sql.SQLContext;
+import org.apache.spark.sql.SparkSession;
 import org.bson.Document;
 import org.junit.Test;
 
@@ -37,13 +37,13 @@ public final class MongoDataFrameWriterTest extends JavaRequiresMongoDB {
         // Given
         JavaSparkContext jsc = getJavaSparkContext();
         JavaRDD<CharacterBean> people = jsc.parallelize(characters).map(JsonToCharacter);
-        SQLContext sqlContext = SQLContext.getOrCreate(jsc.sc());
+        SparkSession sparkSession = SparkSession.builder().getOrCreate();
 
         // When
-        MongoSpark.write(sqlContext.createDataFrame(people, CharacterBean.class)).save();
+        MongoSpark.write(sparkSession.createDataFrame(people, CharacterBean.class)).save();
 
         // Then
-        assertEquals(MongoSpark.read(sqlContext).load().count(), 9);
+        assertEquals(MongoSpark.read(sparkSession).load().count(), 9);
     }
 
     @Test
@@ -51,13 +51,13 @@ public final class MongoDataFrameWriterTest extends JavaRequiresMongoDB {
         // Given
         JavaSparkContext jsc = getJavaSparkContext();
         JavaRDD<CharacterBean> people = jsc.parallelize(characters).map(JsonToCharacter);
-        SQLContext sqlContext = SQLContext.getOrCreate(jsc.sc());
+        SparkSession sparkSession = SparkSession.builder().getOrCreate();
 
         // When
-        MongoSpark.write(sqlContext.createDataFrame(people, CharacterBean.class)).save();
+        MongoSpark.write(sparkSession.createDataFrame(people, CharacterBean.class)).save();
 
         // Then
-        assertEquals(MongoSpark.read(sqlContext).load().count(), 9);
+        assertEquals(MongoSpark.read(sparkSession).load().count(), 9);
     }
 
 
@@ -72,13 +72,13 @@ public final class MongoDataFrameWriterTest extends JavaRequiresMongoDB {
         ReadConfig readConfig = ReadConfig.create(jsc.getConf()).withOptions(options);
 
         JavaRDD<CharacterBean> people = jsc.parallelize(characters).map(JsonToCharacter);
-        SQLContext sqlContext = SQLContext.getOrCreate(jsc.sc());
+        SparkSession sparkSession = SparkSession.builder().getOrCreate();
 
         // When
-        MongoSpark.write(sqlContext.createDataFrame(people, CharacterBean.class)).options(writeConfig.asOptions()).save();
+        MongoSpark.write(sparkSession.createDataFrame(people, CharacterBean.class)).options(writeConfig.asOptions()).save();
 
         // Then
-        assertEquals(MongoSpark.read(sqlContext).options(readConfig.asOptions()).load().count(), 9);
+        assertEquals(MongoSpark.read(sparkSession).options(readConfig.asOptions()).load().count(), 9);
     }
 
     private static Function<String, CharacterBean> JsonToCharacter = new Function<String, CharacterBean>() {

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -27,7 +27,7 @@ log4j.category.org.mongodb.driver.connection=WARN
 
 # Spark levels
 log4j.category.org.spark-project.jetty=WARN
+log4j.category.org.spark_project.jetty.server=WARN
 log4j.category.org.apache.spark=WARN
 log4j.category.akka=WARN
 log4j.category.Remoting=WARN
-

--- a/src/test/scala/com/mongodb/spark/NoSparkConfSpec.scala
+++ b/src/test/scala/com/mongodb/spark/NoSparkConfSpec.scala
@@ -16,7 +16,7 @@
 
 package com.mongodb.spark
 
-import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.{SparkConf, SparkContext}
 
 import org.bson.Document
@@ -41,8 +41,8 @@ class NoSparkConfSpec extends RequiresMongoDB {
   "DataFrame Readers and Writers" should "be able to accept just options" in {
     val characters = Seq(Character("Gandalf", 1000), Character("Bilbo Baggins", 50)) //scalastyle:ignore
 
-    val sqlContext = SQLContext.getOrCreate(sc)
-    import sqlContext.implicits._
+    val sparkSession = SparkSession.builder().getOrCreate()
+    import sparkSession.implicits._
     sc.parallelize(characters).toDF().write
       .option("mode", "Overwrite")
       .option("uri", mongoClientURI)
@@ -50,7 +50,7 @@ class NoSparkConfSpec extends RequiresMongoDB {
       .option("collection", collectionName)
       .mongo()
 
-    val ds = sqlContext.read
+    val ds = sparkSession.read
       .option("uri", mongoClientURI)
       .option("database", databaseName)
       .option("collection", collectionName)

--- a/src/test/scala/com/mongodb/spark/SparkConfOverrideSpec.scala
+++ b/src/test/scala/com/mongodb/spark/SparkConfOverrideSpec.scala
@@ -16,7 +16,7 @@
 
 package com.mongodb.spark
 
-import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.{SparkConf, SparkContext}
 
 import org.bson.Document
@@ -41,8 +41,8 @@ class SparkConfOverrideSpec extends RequiresMongoDB {
   "DataFrame Readers and Writers" should "be able to able to override partial configs with options" in {
     val characters = Seq(Character("Gandalf", 1000), Character("Bilbo Baggins", 50)) //scalastyle:ignore
 
-    val sqlContext = SQLContext.getOrCreate(sc)
-    import sqlContext.implicits._
+    val sparkSession = SparkSession.builder().getOrCreate()
+    import sparkSession.implicits._
     sc.parallelize(characters).toDF().write
       .option("mode", "Overwrite")
       .option("uri", mongoClientURI)
@@ -50,7 +50,7 @@ class SparkConfOverrideSpec extends RequiresMongoDB {
       .option("collection", collectionName)
       .mongo()
 
-    val ds = sqlContext.read
+    val ds = sparkSession.read
       .option("uri", mongoClientURI)
       .option("database", databaseName)
       .option("collection", collectionName)

--- a/src/test/scala/com/mongodb/spark/sql/BsonValuesAsStringClass.scala
+++ b/src/test/scala/com/mongodb/spark/sql/BsonValuesAsStringClass.scala
@@ -16,7 +16,7 @@
 
 package com.mongodb.spark.sql
 
-case class BsonValuesAsStringClass(nullValue: String, int32: String, int64: String, boolean: String, date: String, double: String,
+case class BsonValuesAsStringClass(nullValue: String, int32: String, int64: String, bool: String, date: String, dbl: String,
                                    string: String, minKey: String, maxKey: String, objectId: String, code: String, codeWithScope: String,
                                    regex: String, symbol: String, timestamp: String, undefined: String, binary: String, oldBinary: String,
                                    arrayInt: String, document: String, dbPointer: String)

--- a/src/test/scala/com/mongodb/spark/sql/MongoDataFrameSpec.scala
+++ b/src/test/scala/com/mongodb/spark/sql/MongoDataFrameSpec.scala
@@ -27,10 +27,7 @@ import org.bson._
 import org.bson.types.ObjectId
 import com.mongodb.spark._
 import com.mongodb.spark.config.WriteConfig
-import com.mongodb.spark.rdd.MongoRDD
 import com.mongodb.spark.sql.types.BsonCompatibility
-
-import org.scalatest.FlatSpec
 
 class MongoDataFrameSpec extends RequiresMongoDB {
   // scalastyle:off magic.number
@@ -187,9 +184,9 @@ class MongoDataFrameSpec extends RequiresMongoDB {
       nullValue = "null",
       int32 = "42",
       int64 = "52",
-      boolean = "true",
+      bool = "true",
       date = """{ "$date" : 1463497097 }""",
-      double = "62.0",
+      dbl = "62.0",
       string = "spark connector",
       minKey = """{ "$minKey" : 1 }""",
       maxKey = """{ "$maxKey" : 1 }""",
@@ -226,9 +223,9 @@ class MongoDataFrameSpec extends RequiresMongoDB {
     document.put("nullValue", new BsonNull())
     document.put("int32", new BsonInt32(42))
     document.put("int64", new BsonInt64(52L))
-    document.put("boolean", new BsonBoolean(true))
+    document.put("bool", new BsonBoolean(true))
     document.put("date", new BsonDateTime(1463497097))
-    document.put("double", new BsonDouble(62.0))
+    document.put("dbl", new BsonDouble(62.0))
     document.put("string", new BsonString("spark connector"))
     document.put("minKey", new BsonMinKey())
     document.put("maxKey", new BsonMaxKey())

--- a/src/test/scala/com/mongodb/spark/sql/fieldTypes/FieldTypesSpec.scala
+++ b/src/test/scala/com/mongodb/spark/sql/fieldTypes/FieldTypesSpec.scala
@@ -17,10 +17,9 @@
 package com.mongodb.spark.sql.fieldTypes
 
 import java.util.regex.Pattern
-
 import scala.collection.JavaConverters._
 
-import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.SparkSession
 
 import org.bson.{BsonBinary, _}
 import com.mongodb.spark._
@@ -59,7 +58,7 @@ class FieldTypesSpec extends RequiresMongoDB {
     database.getCollection(collectionName, classOf[BsonDocument]).insertOne(bsonDocument)
     val newCollectionName = s"${collectionName}_new"
 
-    SQLContext.getOrCreate(sc).read.mongo[BsonTypesCaseClass]().write.option("collection", newCollectionName).mongo()
+    SparkSession.builder().getOrCreate().read.mongo[BsonTypesCaseClass]().write.option("collection", newCollectionName).mongo()
     val original = database.getCollection(collectionName).find().iterator().asScala.toList.head
     val copied = database.getCollection(newCollectionName).find().iterator().asScala.toList.head
     copied should equal(original)


### PR DESCRIPTION
Deprecated public methods using SQLContext. In Spark 2.0 SQLContext
is a wrapper of SparkSession and is the preferred class.

SPARK-47