### PR TITLE
Added support for partial partitioning of collections

### DIFF
--- a/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoSplitVectorPartitioner.scala
+++ b/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoSplitVectorPartitioner.scala
@@ -22,10 +22,10 @@ import scala.collection.JavaConverters._
 import scala.util.{Failure, Success, Try}
 
 import org.bson._
-import com.mongodb.{MongoCommandException, MongoNotPrimaryException}
 import com.mongodb.spark.MongoConnector
 import com.mongodb.spark.config.ReadConfig
 import com.mongodb.spark.exceptions.MongoPartitionerException
+import com.mongodb.{MongoCommandException, MongoNotPrimaryException}
 
 /**
  * The SplitVector Partitioner.
@@ -64,15 +64,19 @@ class MongoSplitVectorPartitioner extends MongoPartitioner {
     val partitionSize = partitionerOptions.getOrElse(partitionSizeMBProperty, DefaultPartitionSizeMB).toInt
 
     val keyPattern: BsonDocument = new BsonDocument(partitionKey, new BsonInt32(1))
+    val minKeyMaxKey = PartitionerHelper.getRangeFilterFromPipeline(partitionKey, pipeline)
+
     val splitVectorCommand: BsonDocument = new BsonDocument("splitVector", new BsonString(ns))
       .append("keyPattern", keyPattern)
       .append("maxChunkSize", new BsonInt32(partitionSize))
+      .append("min", new BsonDocument(partitionKey, minKeyMaxKey._1))
+      .append("max", new BsonDocument(partitionKey, minKeyMaxKey._2))
 
     connector.withDatabaseDo(readConfig, { db =>
       Try(db.runCommand(splitVectorCommand, classOf[BsonDocument])) match {
         case Success(result: BsonDocument) =>
           val locations: Seq[String] = connector.withMongoClientDo(mongoClient => mongoClient.getAllAddress.asScala.map(_.getHost).distinct)
-          createPartitions(partitionKey, result, locations)
+          createPartitions(partitionKey, result, locations, minKeyMaxKey)
         case Failure(e: MongoNotPrimaryException) =>
           logWarning("The `SplitVector` command must be run on the primary node")
           throw e
@@ -84,11 +88,12 @@ class MongoSplitVectorPartitioner extends MongoPartitioner {
     })
   }
 
-  private def createPartitions(partitionKey: String, result: BsonDocument, locations: Seq[String]): Array[MongoPartition] = {
+  private def createPartitions(partitionKey: String, result: BsonDocument, locations: Seq[String], minMaxKey: (BsonValue, BsonValue)): Array[MongoPartition] = {
     result.getDouble("ok").getValue match {
       case 1.0 =>
-        val rightHandPartitionBoundaries = result.get("splitKeys").asInstanceOf[util.List[BsonDocument]].asScala.map(_.get(partitionKey))
-        val partitions = PartitionerHelper.createPartitions(partitionKey, rightHandPartitionBoundaries, locations)
+        val splitKeys = result.get("splitKeys").asInstanceOf[util.List[BsonDocument]].asScala.map(_.get(partitionKey))
+        val rightHandBoundaries = minMaxKey._1 +: splitKeys :+ minMaxKey._2
+        val partitions = PartitionerHelper.createPartitions(partitionKey, rightHandBoundaries, locations, false)
         if (partitions.length == 1) {
           logInfo(
             """No splitKeys were calculated by the splitVector command, proceeding with a single partition.

--- a/src/main/scala/com/mongodb/spark/rdd/partitioner/PartitionerHelper.scala
+++ b/src/main/scala/com/mongodb/spark/rdd/partitioner/PartitionerHelper.scala
@@ -16,6 +16,7 @@
 
 package com.mongodb.spark.rdd.partitioner
 
+import scala.annotation.tailrec
 import scala.collection.JavaConverters._
 
 import org.bson._
@@ -48,12 +49,14 @@ object PartitionerHelper {
    * Creates partitions using a single Seq of documents representing the right handside of partitions
    *
    * @param partitionKey the key representing the partition most likely the `_id`.
-   * @param partitions the documents representing a split
+   * @param splitKeys the documents representing a split
    * @param locations the optional server hostnames for the data
+   * @param addMinMax add min and maxkey query bounds.
    * @return
    */
-  def createPartitions(partitionKey: String, partitions: Seq[BsonValue], locations: Seq[String] = Nil): Array[MongoPartition] = {
-    val minToMaxSplitKeys: Seq[BsonValue] = new BsonMinKey() +: partitions :+ new BsonMaxKey()
+  def createPartitions(partitionKey: String, splitKeys: Seq[BsonValue], locations: Seq[String] = Nil, addMinMax: Boolean = true): Array[MongoPartition] = {
+    val minKeyMaxKeys = (new BsonMinKey(), new BsonMaxKey())
+    val minToMaxSplitKeys: Seq[BsonValue] = if (addMinMax) minKeyMaxKeys._1 +: splitKeys :+ minKeyMaxKeys._2 else splitKeys
     val partitionPairs: Seq[(BsonValue, BsonValue)] = minToMaxSplitKeys zip minToMaxSplitKeys.tail
     partitionPairs.zipWithIndex.map({
       case ((min: BsonValue, max: BsonValue), i: Int) => MongoPartition(i, createBoundaryQuery(partitionKey, min, max), locations)
@@ -79,6 +82,74 @@ object PartitionerHelper {
   def collStats(connector: MongoConnector, readConfig: ReadConfig): BsonDocument = {
     val collStatsCommand: BsonDocument = new BsonDocument("collStats", new BsonString(readConfig.collectionName))
     connector.withDatabaseDo(readConfig, { db => db.runCommand(collStatsCommand, readConfig.readPreference, classOf[BsonDocument]) })
+  }
+
+  /**
+   * Returns the head `\$match` from a pipeline
+   *
+   * @param pipeline the users pipeline
+   * @return the head `\$match` or an empty `BsonDocument`.
+   */
+  def matchQuery(pipeline: Array[BsonDocument]): BsonDocument = {
+    val defaultQuery = new BsonDocument()
+    pipeline.headOption match {
+      case Some(document) => document.getDocument("$match", defaultQuery)
+      case None           => defaultQuery
+    }
+  }
+
+  /**
+   * Checks an aggregation pipeline to see if it starts with a range based query.
+   *
+   * If it does it returns the `\$match` filter otherwise None
+   *
+   * @param pipeline the aggregation pipeline
+   * @return the min and max keys for the pipeline
+   * @since 2.1
+   */
+  def getRangeFilterFromPipeline(partitionKey: String, pipeline: Array[BsonDocument]): (BsonValue, BsonValue) = {
+    val filter = pipeline.headOption match {
+      case Some(document: BsonDocument) => getNestedDocument(Seq("$match", partitionKey), document)
+      case None                         => new BsonDocument()
+    }
+    (filter.get("$gte", new BsonMinKey()), filter.get("$lt", new BsonMaxKey()))
+  }
+
+  /**
+   * Sets the final boundary to use `\$lte` rather than `\$lt` so that boundaries with users provided queries have the correct upper bound
+   *
+   * @param partitionKey the partition key
+   * @param partitions the partitions
+   * @return the updated partitions
+   * @since 2.1
+   */
+  def setLastBoundaryToLessThanOrEqualTo(partitionKey: String, partitions: Array[MongoPartition]): Array[MongoPartition] = {
+    val lastPartition = partitions.reverse.head
+    val partitionQuery = lastPartition.queryBounds.getDocument(partitionKey)
+    partitionQuery.append("$lte", partitionQuery.remove("$lt"))
+    partitions
+  }
+
+  /**
+   * Gets a nested document from a document
+   *
+   * @param keys the keys for the document fields
+   * @param document the document to do a nested document lookup
+   * @return the subDocument
+   */
+  @tailrec
+  private def getNestedDocument(keys: Seq[String], document: BsonDocument): BsonDocument = {
+    if (keys.nonEmpty && document.containsKey(keys.head)) {
+      val bsonValue = document.get(keys.head)
+      if (bsonValue.isDocument) {
+        val subDoc = bsonValue.asDocument()
+        if (keys.tail.isEmpty) subDoc else getNestedDocument(keys.tail, subDoc)
+      } else {
+        new BsonDocument()
+      }
+    } else {
+      new BsonDocument()
+    }
   }
 
 }

--- a/src/test/scala/com/mongodb/spark/rdd/partitioner/MongoSplitVectorPartitionerSpec.scala
+++ b/src/test/scala/com/mongodb/spark/rdd/partitioner/MongoSplitVectorPartitionerSpec.scala
@@ -16,8 +16,10 @@
 
 package com.mongodb.spark.rdd.partitioner
 
+import org.apache.spark.sql.SparkSession
+
 import org.bson.{BsonDocument, Document}
-import com.mongodb.spark.{MongoConnector, RequiresMongoDB}
+import com.mongodb.spark.{MongoConnector, MongoSpark, RequiresMongoDB}
 
 class MongoSplitVectorPartitionerSpec extends RequiresMongoDB {
 
@@ -46,6 +48,34 @@ class MongoSplitVectorPartitionerSpec extends RequiresMongoDB {
       readConfig.copy(partitionerOptions = Map("partitionSizeMB" -> "10")), pipeline
     ).length shouldBe 1
   }
+
+  it should "use the provided pipeline for min and max keys" in {
+    loadSampleData(10)
+
+    val readConf = readConfig.copy(partitionerOptions = Map("partitionSizeMB" -> "1"))
+    val rangePipeline = Array(BsonDocument.parse(s"""{$$match: { $partitionKey: {$$gte: "00001", $$lt: "00022"}}}"""))
+
+    val rangePartitions = MongoSplitVectorPartitioner.partitions(mongoConnector, readConf, rangePipeline)
+    getQueryBoundForKey(rangePartitions.head, "$gte") should equal("00001")
+    getQueryBoundForKey(rangePartitions.reverse.head, "$lt") should equal("00022")
+    rangePartitions.length should (be >= 4 and be <= 5)
+  }
+
+  it should "use the users pipeline when set in a rdd / dataframe" in {
+    loadSampleData(10)
+
+    val readConf = readConfig.copy(partitioner = MongoSplitVectorPartitioner, partitionerOptions = Map("partitionSizeMB" -> "1"))
+    val rangePipeline = BsonDocument.parse(s"""{$$match: { $partitionKey: {$$gte: "00001", $$lt: "00031"}}}""")
+
+    val sparkSession = SparkSession.builder().getOrCreate()
+    val rdd = MongoSpark.load(sparkSession.sparkContext, readConf).withPipeline(Seq(rangePipeline))
+    rdd.count() should equal(30)
+    rdd.partitions.length should (be >= 6 and be <= 7)
+
+    val df = MongoSpark.load(sparkSession, readConf).filter(s"""$partitionKey >= "00001" AND  $partitionKey < "00031"""")
+    df.rdd.count() should equal(30)
+    df.rdd.partitions.length should (be >= 6 and be <= 7)
+  }
   // scalastyle:on magic.number
 
   it should "have a default bounds of min to max key" in {
@@ -65,4 +95,8 @@ class MongoSplitVectorPartitionerSpec extends RequiresMongoDB {
     val expectedPartitions = MongoSinglePartitioner.partitions(mongoConnector, readConfig, pipeline)
     MongoSplitVectorPartitioner.partitions(mongoConnector, readConfig, pipeline) should equal(expectedPartitions)
   }
+
+  private def getQueryBoundForKey(partition: MongoPartition, key: String): String =
+    partition.queryBounds.getDocument(partitionKey).getString(key).getValue
+
 }


### PR DESCRIPTION
If a user provides a pipeline where the first stage is a $match query then the non-sharded partitioners will only partition part of the collection.

SPARK-101