### PR TITLE
Ensure the SamplePartitioner always includes min and max bounds

### DIFF
--- a/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoSamplePartitioner.scala
+++ b/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoSamplePartitioner.scala
@@ -106,10 +106,7 @@ class MongoSamplePartitioner extends MongoPartitioner {
           val rightHandBoundaries = samples.zipWithIndex.collect {
             case (field, i) if collectSplit(i) => field.get(partitionKey)
           }
-          val addMinMax = matchQuery.isEmpty
-          val partitions = PartitionerHelper.createPartitions(partitionKey, rightHandBoundaries, PartitionerHelper.locations(connector), addMinMax)
-          if (!addMinMax) PartitionerHelper.setLastBoundaryToLessThanOrEqualTo(partitionKey, partitions)
-          partitions
+          PartitionerHelper.createPartitions(partitionKey, rightHandBoundaries, PartitionerHelper.locations(connector))
         }
 
       case Failure(ex: MongoCommandException) if ex.getErrorMessage.endsWith("not found.") || ex.getErrorCode == 26 =>

--- a/src/test/scala/com/mongodb/spark/MongoDBDefaults.scala
+++ b/src/test/scala/com/mongodb/spark/MongoDBDefaults.scala
@@ -97,26 +97,24 @@ class MongoDBDefaults extends Logging {
     }
   }
 
-  def loadSampleData(collectionName: String, sizeInMB: Int): Unit = {
+  def loadSampleData(collectionName: String, sizeInMB: Int, numberOfDocuments: Int): Unit = {
     assert(isMongoDBOnline(), "MongoDB offline")
     assert(sizeInMB > 0, "Size in MB must be more than ")
     logInfo(s"Loading sample Data: ~${sizeInMB}MB data into '$collectionName'")
     val collection: MongoCollection[BsonDocument] = mongoClient.getDatabase(DATABASE_NAME)
       .withReadPreference(ReadPreference.primary())
       .getCollection(collectionName, classOf[BsonDocument])
-    val numberOfDocuments: Int = 10
 
-    val fieldLength: Int = (1024 * 1024 / numberOfDocuments) - 60 // One MB / number of Documents - Some padding
+    val sizeBytes = (1024 * 1024) * sizeInMB
+    val fieldLength = sizeBytes / numberOfDocuments
     var counter = 0
-    (1 to sizeInMB).foreach({ x =>
-      val sampleString: String = Random.alphanumeric.take(fieldLength).mkString
-      val documents: IndexedSeq[BsonDocument] = (1 to numberOfDocuments).map(y => {
-        counter += 1
-        val idValue = new BsonString(f"$counter%05d")
-        new BsonDocument("_id", idValue).append("pk", idValue).append("s", new BsonString(sampleString))
-      })
-      collection.insertMany(documents.toList.asJava)
+    val sampleString: String = Random.alphanumeric.take(fieldLength - 60).mkString
+    val documents: IndexedSeq[BsonDocument] = (1 to numberOfDocuments).map(y => {
+      counter += 1
+      val idValue = new BsonString(f"$counter%05d")
+      new BsonDocument("_id", idValue).append("pk", idValue).append("s", new BsonString(sampleString))
     })
+    collection.insertMany(documents.toList.asJava)
   }
 
   def loadSampleDataCompositeKey(collectionName: String, sizeInMB: Int): Unit = {

--- a/src/test/scala/com/mongodb/spark/RequiresMongoDB.scala
+++ b/src/test/scala/com/mongodb/spark/RequiresMongoDB.scala
@@ -91,7 +91,10 @@ trait RequiresMongoDB extends FlatSpec with Matchers with BeforeAndAfterAll with
 
   def loadSampleData(filename: String): Unit = mongoDBDefaults.loadSampleData(readConfig.collectionName, filename)
 
-  def loadSampleData(sizeInMB: Int): Unit = mongoDBDefaults.loadSampleData(readConfig.collectionName, sizeInMB)
+  def loadSampleData(sizeInMB: Int): Unit = loadSampleData(sizeInMB, sizeInMB * 10)
+
+  def loadSampleData(sizeInMB: Int, numberOfDocuments: Int): Unit =
+    mongoDBDefaults.loadSampleData(readConfig.collectionName, sizeInMB, numberOfDocuments)
 
   def loadSampleDataCompositeKey(sizeInMB: Int): Unit = mongoDBDefaults.loadSampleDataCompositeKey(readConfig.collectionName, sizeInMB)
 


### PR DESCRIPTION
Fixes a partitioning bug when providing $match queries

SPARK-151